### PR TITLE
Tell Fabric to explicitly use the user's ssh config

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ OpenCodelists is currently deployed to smallweb1.  Deployment is with fabric:
 fab deploy
 ```
 
+You will need to configure SSH agent forwarding in your `~/.ssh/config`, e.g.
+
+    Host smallweb1.ebmdatalab.net
+    ForwardAgent yes
+    User <your user on smallweb1>
+
+
+macOS users will need to configure their SSH Agent to add their key by default as per [GitHub's Docs](https://docs.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#adding-your-ssh-key-to-the-ssh-agent).
+
 On the server, use `with_environment.sh` to run a management command in the virtual environment with the correct settings:
 
 ```

--- a/fabfile.py
+++ b/fabfile.py
@@ -8,6 +8,7 @@ env.colorize_errors = True
 env.hosts = ["smallweb1.ebmdatalab.net"]
 env.user = "root"
 env.path = "/var/www/opencodelists"
+env.use_ssh_config = True
 
 
 def initalise_directory():


### PR DESCRIPTION
This sets `env.use_ssh_config` to `True` and documents SSH config changes one might need to make to be able to deploy.

While working out how to get deploys working from my environment we tried a number of things and various SSH config changes were suggested.  The README change covers what should be the bare minimium to get deploys working.