### PR TITLE
Add Sign-Offs and References

### DIFF
--- a/codelists/forms.py
+++ b/codelists/forms.py
@@ -52,7 +52,6 @@ class CodelistForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         self.helper = FormHelper()
         self.helper.form_tag = False
-        self.helper.disable_csrf = True
         super().__init__(*args, **kwargs)
 
 

--- a/codelists/forms.py
+++ b/codelists/forms.py
@@ -2,7 +2,44 @@ from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit
 from django import forms
 
-from .models import Codelist, CodelistVersion
+from .models import Codelist, CodelistVersion, Reference, SignOff
+
+
+class FormSetHelper(FormHelper):
+    """
+    FormHelper for use with Crispy Forms and FormSets
+
+    When using Crispy Forms helpers with FormSet their layout is applied to the
+    Forms but attributes to the FormSet, so we need to pass the FormHelper
+    instance into the crispy_forms templatetag in the view.
+
+    https://django-crispy-forms.readthedocs.io/en/latest/crispy_tag_formsets.html#formsets
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.disable_csrf = True
+        self.form_tag = False
+
+
+class ReferenceForm(forms.ModelForm):
+    class Meta:
+        model = Reference
+        fields = [
+            "text",
+            "url",
+        ]
+
+
+class SignOffForm(forms.ModelForm):
+    date = forms.DateField(widget=forms.TextInput(attrs={"type": "date"}))
+
+    class Meta:
+        model = SignOff
+        fields = [
+            "user",
+            "date",
+        ]
 
 
 class CodelistForm(forms.ModelForm):
@@ -14,7 +51,8 @@ class CodelistForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         self.helper = FormHelper()
-        self.helper.add_input(Submit("submit", "Submit"))
+        self.helper.form_tag = False
+        self.helper.disable_csrf = True
         super().__init__(*args, **kwargs)
 
 

--- a/codelists/tests/factories.py
+++ b/codelists/tests/factories.py
@@ -1,9 +1,9 @@
 from codelists import actions
-from opencodelists.tests.factories import create_project
+from opencodelists.tests.factories import ProjectFactory
 
 
 def create_codelist():
-    p = create_project()
+    p = ProjectFactory()
     return actions.create_codelist(
         project=p,
         name="Test Codelist",

--- a/codelists/tests/test_actions.py
+++ b/codelists/tests/test_actions.py
@@ -1,6 +1,7 @@
 import pytest
 
 from codelists import actions
+from opencodelists.tests.factories import ProjectFactory
 
 from . import factories
 
@@ -8,7 +9,7 @@ pytestmark = pytest.mark.freeze_time("2020-07-23")
 
 
 def test_create_codelist():
-    p = factories.create_project()
+    p = ProjectFactory()
     cl = actions.create_codelist(
         project=p,
         name="Test Codelist",

--- a/codelists/tests/test_views.py
+++ b/codelists/tests/test_views.py
@@ -1,9 +1,11 @@
 import csv
 from io import BytesIO, StringIO
+from unittest.mock import patch
 
 import pytest
 from pytest_django.asserts import assertContains, assertRedirects
 
+from codelists.views import CreateCodelist
 from opencodelists.tests.factories import ProjectFactory, UserFactory
 
 from . import factories
@@ -18,8 +20,12 @@ def logged_in_client(client, django_user_model):
     return client
 
 
-def test_create_codelist(logged_in_client):
-    p = ProjectFactory()
+def test_createcodelist_success(rf):
+    project = ProjectFactory()
+    signoff_user = UserFactory()
+
+    assert project.codelists.count() == 0
+
     csv_data = "code,description\n1067731000000107,Injury whilst swimming (disorder)"
     data = {
         "name": "Test Codelist",
@@ -27,9 +33,84 @@ def test_create_codelist(logged_in_client):
         "description": "This is a test",
         "methodology": "This is how we did it",
         "csv_data": _build_file_for_upload(csv_data),
+        "reference-TOTAL_FORMS": "1",
+        "reference-INITIAL_FORMS": "0",
+        "reference-MIN_NUM_FORMS": "0",
+        "reference-MAX_NUM_FORMS": "1000",
+        "reference-0-text": "foo",
+        "reference-0-url": "http://example.com",
+        "signoff-TOTAL_FORMS": "1",
+        "signoff-INITIAL_FORMS": "0",
+        "signoff-MIN_NUM_FORMS": "0",
+        "signoff-MAX_NUM_FORMS": "1000",
+        "signoff-0-user": signoff_user.username,
+        "signoff-0-date": "2020-01-23",
     }
-    rsp = logged_in_client.post(f"/codelist/{p.slug}/", data, follow=True)
-    assertRedirects(rsp, f"/codelist/{p.slug}/test-codelist/2020-07-23-draft/")
+
+    request = rf.post("/", data=data)
+    request.user = UserFactory()
+    response = CreateCodelist.as_view()(request, project_slug=project.slug)
+
+    assert response.status_code == 302
+    assert response.url == f"/codelist/{project.slug}/test-codelist/"
+
+    assert project.codelists.count() == 1
+    codelist = project.codelists.first()
+    assert codelist.name == "Test Codelist"
+
+    # we should have one reference to example.com
+    assert codelist.references.count() == 1
+    ref = codelist.references.first()
+    assert ref.url == "http://example.com"
+
+    # we should have one signoff by signoff user
+    assert codelist.signoffs.count() == 1
+    signoff = codelist.signoffs.first()
+    assert signoff.user == signoff_user
+
+
+def test_createcodelist_invalid_post(rf):
+    project = ProjectFactory()
+    signoff_user = UserFactory()
+
+    assert project.codelists.count() == 0
+
+    csv_data = "code,description\n1067731000000107,Injury whilst swimming (disorder)"
+
+    # missing signoff-0-date
+    data = {
+        "name": "Test Codelist",
+        "coding_system_id": "snomedct",
+        "description": "This is a test",
+        "methodology": "This is how we did it",
+        "csv_data": _build_file_for_upload(csv_data),
+        "reference-TOTAL_FORMS": "1",
+        "reference-INITIAL_FORMS": "0",
+        "reference-MIN_NUM_FORMS": "0",
+        "reference-MAX_NUM_FORMS": "1000",
+        "reference-0-text": "foo",
+        "reference-0-url": "http://example.com",
+        "signoff-TOTAL_FORMS": "1",
+        "signoff-INITIAL_FORMS": "0",
+        "signoff-MIN_NUM_FORMS": "0",
+        "signoff-MAX_NUM_FORMS": "1000",
+        "signoff-0-user": signoff_user.username,
+    }
+
+    request = rf.post("/", data=data)
+
+    view = CreateCodelist()
+    view.setup(request)
+    with patch("codelists.views.CreateCodelist.all_valid") as mock_all_valid, patch(
+        "codelists.views.CreateCodelist.some_invalid"
+    ) as mock_some_invalid:
+        view.post(request)
+
+    # was the error handler, some_invalid, called?
+    # we're not doing any custom error handling in the form or formsets so no
+    # need to test what Django is already testing
+    mock_all_valid.assert_not_called()
+    mock_some_invalid.assert_called_once()
 
 
 def test_create_codelist_when_not_logged_in(client):

--- a/codelists/tests/test_views.py
+++ b/codelists/tests/test_views.py
@@ -4,7 +4,7 @@ from io import BytesIO, StringIO
 import pytest
 from pytest_django.asserts import assertContains, assertRedirects
 
-from opencodelists.tests import factories as opencodelists_factories
+from opencodelists.tests.factories import ProjectFactory, UserFactory
 
 from . import factories
 
@@ -14,13 +14,12 @@ pytestmark = pytest.mark.freeze_time("2020-07-23")
 @pytest.fixture()
 def logged_in_client(client, django_user_model):
     """A Django test client logged in a user."""
-    user = opencodelists_factories.create_user()
-    client.force_login(user)
+    client.force_login(UserFactory())
     return client
 
 
 def test_create_codelist(logged_in_client):
-    p = factories.create_project()
+    p = ProjectFactory()
     csv_data = "code,description\n1067731000000107,Injury whilst swimming (disorder)"
     data = {
         "name": "Test Codelist",
@@ -34,7 +33,7 @@ def test_create_codelist(logged_in_client):
 
 
 def test_create_codelist_when_not_logged_in(client):
-    p = factories.create_project()
+    p = ProjectFactory()
     csv_data = "code,description\n1067731000000107,Injury whilst swimming (disorder)"
     data = {
         "name": "Test Codelist",

--- a/codelists/urls.py
+++ b/codelists/urls.py
@@ -36,7 +36,11 @@ urlpatterns = [
     ),
     # ~~~
     path("", views.index, name="index"),
-    path("codelist/<project_slug>/", views.create_codelist, name="create_codelist"),
+    path(
+        "codelist/<project_slug>/",
+        views.CreateCodelist.as_view(),
+        name="create_codelist",
+    ),
     path("codelist/<project_slug>/<codelist_slug>/", views.codelist, name="codelist"),
     path(
         "codelist/<project_slug>/<codelist_slug>/<qualified_version_str>/",

--- a/opencodelists/settings.py
+++ b/opencodelists/settings.py
@@ -150,9 +150,8 @@ USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.0/howto/static-files/
-
+STATICFILES_DIRS = [os.path.join(BASE_DIR, "static")]
 STATIC_URL = "/static/"
-
 WHITENOISE_USE_FINDERS = True
 
 

--- a/opencodelists/settings.py
+++ b/opencodelists/settings.py
@@ -59,6 +59,7 @@ INSTALLED_APPS = [
     "corsheaders",
     "crispy_forms",
     "django_extensions",
+    "debug_toolbar",
     "markdown_filter",
     "django.contrib.admin",
     "django.contrib.auth",
@@ -78,6 +79,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "debug_toolbar.middleware.DebugToolbarMiddleware",
 ]
 
 ROOT_URLCONF = "opencodelists.urls"
@@ -223,3 +225,9 @@ MARKDOWN_FILTER_WHITELIST_TAGS = [
 
 # Login/logout config
 LOGOUT_REDIRECT_URL = "/"
+
+
+# Debug Toolbar
+INTERNAL_IPS = [
+    "127.0.0.1",
+]

--- a/opencodelists/tests/factories.py
+++ b/opencodelists/tests/factories.py
@@ -1,21 +1,46 @@
+import factory
+
 from opencodelists import actions
-from opencodelists.models import Organisation, User
+from opencodelists.models import Organisation, Project, User
 
 
-def create_organisation():
-    return actions.create_organisation(name="Test University", url="https://test.ac.uk")
+class OrganisationFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Organisation
+
+    name = "Test University"
+    url = "https://test.ac.uk"
+
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        """Override the default ``_create`` with our actions."""
+        return actions.create_organisation(*args, **kwargs)
 
 
-def create_project():
-    o = Organisation.objects.first() or create_organisation()
-    return actions.create_project(
-        name="Test Project",
-        url="https://test.org",
-        details="This is a test",
-        organisations=[o],
-    )
+class ProjectFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Project
+
+    name = "Test Project"
+    url = "https://test.org"
+    details = "This is a test"
+
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        """Override the default ``_create`` with our actions."""
+        o = Organisation.objects.first() or OrganisationFactory()
+        return actions.create_project(*args, organisations=[o], **kwargs)
 
 
-def create_user():
-    o = Organisation.objects.first() or create_organisation()
-    return User.objects.create(name="Alice Apple", organisation=o)
+class UserFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = User
+
+    username = factory.Sequence(lambda n: f"user{n}")
+    email = factory.Sequence(lambda n: f"user{n}@example.com")
+
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        """Override the default ``_create`` with our actions."""
+        o = Organisation.objects.first() or OrganisationFactory()
+        return User.objects.create(organisation=o, **kwargs)

--- a/opencodelists/tests/test_actions.py
+++ b/opencodelists/tests/test_actions.py
@@ -1,6 +1,6 @@
 from opencodelists import actions
 
-from . import factories
+from .factories import OrganisationFactory
 
 
 def test_create_organisation():
@@ -11,7 +11,7 @@ def test_create_organisation():
 
 
 def test_create_project():
-    o = factories.create_organisation()
+    o = OrganisationFactory()
     p = actions.create_project(
         name="Test Project",
         url="https://test.org",

--- a/opencodelists/urls.py
+++ b/opencodelists/urls.py
@@ -1,3 +1,4 @@
+import debug_toolbar
 from django.contrib import admin
 from django.urls import include, path
 
@@ -12,4 +13,5 @@ urlpatterns = [
     path("snomedct/", include("coding_systems.snomedct.urls")),
     path("api/v1/snomedct/", include("coding_systems.snomedct.api_urls")),
     path("project/<project_slug>/", views.project, name="project"),
+    path("__debug__/", include(debug_toolbar.urls)),
 ]

--- a/requirements.in
+++ b/requirements.in
@@ -10,6 +10,7 @@ whitenoise
 sentry-sdk
 
 # test
+factory_boy
 hypothesis
 pytest-django
 pytest-freezegun

--- a/requirements.in
+++ b/requirements.in
@@ -2,6 +2,7 @@ fabric3
 django
 django-crispy-forms
 django-cors-headers
+django-debug-toolbar
 django-markdown-filter
 gunicorn
 pysqlite3-binary

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,8 @@ django-markdown-filter==0.0.1  # via -r requirements.in
 django==3.1               # via -r requirements.in, django-cors-headers, django-markdown-filter
 entrypoints==0.3          # via flake8
 fabric3==1.14.post1       # via -r requirements.in
+factory-boy==2.12.0       # via -r requirements.in
+faker==4.1.1              # via factory-boy
 filelock==3.0.12          # via virtualenv
 flake8==3.8.3             # via -r requirements.in
 freezegun==0.3.15         # via pytest-freezegun
@@ -57,7 +59,7 @@ pysqlite3-binary==0.4.3   # via -r requirements.in
 pytest-django==3.9.0      # via -r requirements.in
 pytest-freezegun==0.4.2   # via -r requirements.in
 pytest==6.0.1             # via pytest-django, pytest-freezegun
-python-dateutil==2.8.1    # via freezegun
+python-dateutil==2.8.1    # via faker, freezegun
 pytz==2020.1              # via django
 pyyaml==5.3.1             # via pre-commit
 regex==2020.4.4           # via black
@@ -67,6 +69,7 @@ sortedcontainers==2.1.0   # via hypothesis
 sqlparse==0.3.1           # via django, django-debug-toolbar, litecli
 tabulate[widechars]==0.8.7  # via cli-helpers
 terminaltables==3.1.0     # via cli-helpers
+text-unidecode==1.3       # via faker
 toml==0.10.0              # via black, pre-commit, pytest
 typed-ast==1.4.1          # via black
 urllib3==1.25.9           # via sentry-sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,9 +20,11 @@ cryptography==2.9.2       # via paramiko
 distlib==0.3.1            # via virtualenv
 django-cors-headers==3.4.0  # via -r requirements.in
 django-crispy-forms==1.9.2  # via -r requirements.in
+django-debug-toolbar==2.2  # via -r requirements.in
 django-extensions==3.0.4  # via -r requirements.in
 django-markdown-filter==0.0.1  # via -r requirements.in
 django==3.1               # via -r requirements.in, django-cors-headers, django-markdown-filter
+entrypoints==0.3          # via flake8
 fabric3==1.14.post1       # via -r requirements.in
 filelock==3.0.12          # via virtualenv
 flake8==3.8.3             # via -r requirements.in
@@ -62,7 +64,7 @@ regex==2020.4.4           # via black
 sentry-sdk==0.16.3        # via -r requirements.in
 six==1.14.0               # via bcrypt, bleach, configobj, cryptography, fabric3, freezegun, packaging, pip-tools, pynacl, python-dateutil, virtualenv
 sortedcontainers==2.1.0   # via hypothesis
-sqlparse==0.3.1           # via django, litecli
+sqlparse==0.3.1           # via django, django-debug-toolbar, litecli
 tabulate[widechars]==0.8.7  # via cli-helpers
 terminaltables==3.1.0     # via cli-helpers
 toml==0.10.0              # via black, pre-commit, pytest

--- a/static/js/create_codelist.js
+++ b/static/js/create_codelist.js
@@ -1,0 +1,15 @@
+const addForm = (name, event) => {
+    const form_idx = $(`#id_${name}-TOTAL_FORMS`).val();
+    const new_form = $(`#${name}-forms .template`).html().replace(/__prefix__/g, form_idx);
+    $(`#${name}-forms`).append('<hr />').append(new_form);
+
+    // Update the number of total forms
+    $(`#id_${name}-TOTAL_FORMS`).val(parseInt(form_idx) + 1);
+
+    event.preventDefault();
+};
+
+$(document).ready(() => {
+    $('#add-reference').click((event) => addForm('reference', event));
+    $('#add-signoff').click((event) => addForm('signoff', event));
+});

--- a/templates/codelists/create_codelist.html
+++ b/templates/codelists/create_codelist.html
@@ -10,8 +10,6 @@
 <h3>New Codelist</h3>
 
 <form method="POST" enctype="multipart/form-data">
-  {% csrf_token %}
-
   <div class="mb-5">
     {% crispy codelist_form %}
   </div>

--- a/templates/codelists/create_codelist.html
+++ b/templates/codelists/create_codelist.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+
 {% load crispy_forms_tags %}
+{% load static %}
 
 {% block title_extra %}: {{ codelist.name }}{% endblock %}
 
@@ -7,5 +9,50 @@
 <br />
 <h3>New Codelist</h3>
 
-{% crispy form %}
+<form method="POST" enctype="multipart/form-data">
+  {% csrf_token %}
+
+  <div class="mb-5">
+    {% crispy codelist_form %}
+  </div>
+
+  <div id="reference-forms" class="mb-5">
+
+    <div class="d-flex justify-content-between">
+      <h4>References</h4>
+      <button id="add-reference" class="btn btn-success">+</button>
+    </div>
+
+    <div class="d-none template">
+      {% crispy reference_formset.empty_form helper %}
+    </div>
+
+    {% crispy reference_formset helper %}
+
+  </div>
+
+  <div id="signoff-forms" class="mb-5">
+
+    <div class="d-flex justify-content-between">
+      <h4>Sign Offs</h4>
+      <button id="add-signoff" class="btn btn-success">+</button>
+    </div>
+
+    <div class="d-none template">
+      {% crispy signoff_formset.empty_form helper %}
+    </div>
+
+    {% crispy signoff_formset helper %}
+
+  </div>
+
+  <div class="form-group">
+    <button type="submit" class="btn btn-primary">Submit</button>
+  </div>
+</form>
+
+{% endblock %}
+
+{% block extra_js %}
+<script type="text/javascript" src="{% static 'js/create_codelist.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
This adds the ability to add Sign-Offs and References to Codelists when creating them without having to use the Admin.

It uses two formsets to deal with the multiple Signoff/Reference models related to a Codelist and uses a small amount of Javascript to handle adding more forms.

I've switched the create view over to a Class-based View mainly to separate out the code.  It's based on TemplateView because there's no GCBV for dealing with a form and two formsets but I've mirrored how the various methods are used in [CreateView](http://ccbv.co.uk/projects/Django/3.0/django.views.generic.edit/CreateView/) to maintain consistency with the community (eg conditional creation of Form[Set] instances in `get_context_data`).  I also wanted to showcase a strength of CBVs - in more complicated views a class lets you split things up into methods which I find can aid readability.

As part of testing this I needed to have unique email and usernames for each of the Users created so I've added Factory Boy (in a separate commit for ease of review) and combined it with our actions.

---

Testing Discussion!

## Building Data Structures
When we write tests we often need some data structures to run the code we're testing against, factories are great for this and we have some of those already.  However, I like to partition those into two things: factories (building blocks) and fixtures ("things you care about most of the time").

Factories are building blocks because they're a function/class/$thing which produces one or more working model instances.  They're already useful at that point because you often need a single model in a test, eg a `User` for authenticating with a View.

Fixtures are where things start to shine though.  Those larger data structures I talked about in the stand up often need multiple models in various states (eg a fire engine with 3 hoses but one has a leak or something equally appropriate for a codelist 😉).  I like to define fixtures as "things I would like in my tests that I don't want to care [too much] about the internals of".

As a concrete example - we need to pass in a CSV file to create Codelists and create/modify Versions.  In our view tests we have a function to turn a string into a BytesIO object.  The contents of this "file" is nearly identical in every test.  This would be perfect as a fixture, where I could ask for `dummy_csv` in my test and not have to care what's in the CSV, except that it's valid!  The code to create that CSV still exists in conftests as a fixture and we only have to care about it when the CSV isn't correct for a tests we're writing.

## RequestFactorys
I only got introduced to these a few months ago, but I love them.  They let you bypass all of Django's URL routing code and get you closer to the view code you're trying to test.  Relatedly if you like CBVs the `.setup()` method used in conjunction with a RequestFactory means you can test specific methods of a view which I really like for larger views.

## Tests Layout
I tend to put tests in their own directory called `tests` at the top level of the repo.  Testing related files go in there, ie  `factories.py` and `conftests.py`.  Then I mirror the project structure inside that directory (eg `tests/codelists/test_views.py`).  And finally I run them with `pytest [options] tests`.  The biggest pros I've seen for this are:
* slight optimisation of test collection (few files to look at but a bit dubious)
* easier to ignore when building a deployment asset, eg a Docker image

Personally I like the grouping of tests from an organisation standpoint.

Thoughts and options welcome!