### PR TITLE
Only slugify Organisation.slug if it hasn't been set already

### DIFF
--- a/opencodelists/models.py
+++ b/opencodelists/models.py
@@ -85,7 +85,9 @@ class Organisation(models.Model):
     url = models.URLField()
 
     def save(self, *args, **kwargs):
-        self.slug = slugify(self.name)
+        if not self.slug:
+            self.slug = slugify(self.name)
+
         super().save(*args, **kwargs)
 
     def __str__(self):


### PR DESCRIPTION
This fixes a bug where changing an Organisation's name in the admin created a new Organisation since the slug was being regenerated on every save.