### PR TITLE
Configure Dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,6 @@
+version: 1
+
+update_configs:
+  - package_manager: "python"
+    directory: "/"
+    update_schedule: "daily"


### PR DESCRIPTION
This configures Dependabot to batch changes daily.

Do we want to set up reviewers or assignees by default?

Fixes #55 