### PR TITLE
Configure CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-exclude = .direnv,.venv
+exclude = .direnv,.venv,venv
 ignore = \
     E501 \ # line too long (black fixes long lines, except for long strings which may benefit from being long (eg URLs))
     W503   # line break before binary operator (black disagrees)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,106 @@
+---
+name: CI
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.6"
+      - name: "Install dependencies"
+        run: |
+          set -xe
+          python -m pip install --upgrade pip
+          python -m venv venv
+          venv/bin/pip install --progress-bar=off --requirement requirements.txt
+      - name: Cache the venv
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/venv
+          key: venv-${{ github.ref }}-${{ hashFiles('requirements.txt') }}
+
+  format:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.6"
+      - name: Use the cached venv
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/venv
+          key: venv-${{ github.ref }}-${{ hashFiles('requirements.txt') }}
+      - run: ls -lah ${{ github.workspace }}
+      - name: Check formatting
+        run: |
+          source ${{ github.workspace }}/venv/bin/activate
+          make format
+
+  lint:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.6"
+      - name: Use the cached venv
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/venv
+          key: venv-${{ github.ref }}-${{ hashFiles('requirements.txt') }}
+      - name: Check linting
+        run: |
+          source ${{ github.workspace }}/venv/bin/activate
+          make lint
+
+  sort:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.6"
+      - name: Use the cached venv
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/venv
+          key: venv-${{ github.ref }}-${{ hashFiles('requirements.txt') }}
+      - name: Check import sorting
+        run: |
+          source ${{ github.workspace }}/venv/bin/activate
+          make sort
+
+  test:
+    needs: [format, lint, sort]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.6"
+      - name: Use the cached venv
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/venv
+          key: venv-${{ github.ref }}-${{ hashFiles('requirements.txt') }}
+      - name: Run tests
+        run: |
+          source ${{ github.workspace }}/venv/bin/activate
+          make test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,6 @@ name: CI
 
 on:
   push:
-    branches: ["master"]
-  pull_request:
-    branches: ["master"]
 
 jobs:
   build:


### PR DESCRIPTION
This sets up GitHub Actions to mirror my preferred CircleCI workflow, specifically a build step, followed by "trivial" checks, finished up with the [potentially] heavier tests step (we could add a deploy step after tests, I'll save that for #49!).

This is my first time really using GitHub Actions so I've used various open source repos (including our own) alongside the docs to build this config.

One thing to take note of - I've used `venv` from the stdlib to allow us to cache the virtualenv in the build step.  However activating that before each run seems a little clunky.

Fixes #54 