### PR TITLE
Remove Deprecated Isort Option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ deploy:
 .PHONY: fix
 fix:
 	black .
-	isort --recursive .
+	isort .
 
 .PHONY: format
 format:


### PR DESCRIPTION
Another missed change from #59 

Isort 6.x is recursive by default now!