### PR TITLE
Set up Postgres

### DIFF
--- a/opencodelists/settings.py
+++ b/opencodelists/settings.py
@@ -12,14 +12,10 @@ https://docs.djangoproject.com/en/3.0/ref/settings/
 
 
 import os
-import sys
 
+import dj_database_url
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
-
-# Patch sqlite3 to ensure recent version
-__import__("pysqlite3")
-sys.modules["sqlite3"] = sys.modules.pop("pysqlite3")
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -103,13 +99,7 @@ WSGI_APPLICATION = "opencodelists.wsgi.application"
 
 # Database
 # https://docs.djangoproject.com/en/3.0/ref/settings/#databases
-
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
-    }
-}
+DATABASES = {"default": dj_database_url.config(default="sqlite:///db.sqlite3")}
 
 
 # Custom user model

--- a/requirements.in
+++ b/requirements.in
@@ -1,10 +1,11 @@
 fabric3
+dj-database-url
 django
 django-crispy-forms
 django-cors-headers
 django-markdown-filter
 gunicorn
-pysqlite3-binary
+psycopg2
 whitenoise
 sentry-sdk
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ click==7.1.2              # via black, litecli, pip-tools
 configobj==5.0.6          # via cli-helpers, litecli
 cryptography==2.9.2       # via paramiko
 distlib==0.3.1            # via virtualenv
+dj-database-url==0.5.0    # via -r requirements.in
 django-cors-headers==3.4.0  # via -r requirements.in
 django-crispy-forms==1.9.2  # via -r requirements.in
 django-extensions==3.0.4  # via -r requirements.in
@@ -43,6 +44,7 @@ pip-tools==5.3.1          # via -r requirements.in
 pluggy==0.13.1            # via pytest
 pre-commit==2.6.0         # via -r requirements.in
 prompt-toolkit==3.0.5     # via litecli
+psycopg2==2.8.5           # via -r requirements.in
 py==1.9.0                 # via pytest
 pycodestyle==2.6.0        # via flake8
 pycparser==2.20           # via cffi
@@ -50,7 +52,6 @@ pyflakes==2.2.0           # via flake8
 pygments==2.6.1           # via cli-helpers, litecli
 pynacl==1.3.0             # via paramiko
 pyparsing==2.4.7          # via packaging
-pysqlite3-binary==0.4.3   # via -r requirements.in
 pytest-django==3.9.0      # via -r requirements.in
 pytest-freezegun==0.4.2   # via -r requirements.in
 pytest==5.4.3             # via pytest-django, pytest-freezegun


### PR DESCRIPTION
This switches the project to support Postgres by default by installing `psycopg2` instead of `pysqlite3[-binary]`.

Locally I have sqlite3 `3.24.0` from my OS (macOS 10.14 Mojave) which has the `OMIT_LOAD_EXTENSION` compile option set.  This is problematic for [pysqlite3](https://github.com/coleifer/pysqlite3/issues/1) because it needs to load extension(s).  I've managed to work around this by cloning pysqlite3 and building locally once… but can't seem to replicate the it.  However the issue still remains that I can't do `pip install -r requirements.txt` because `pysqlite-binary` isn't compatible with macOS and `pysqlite3` will install but won't run because of the load extension issue.

I've set up settings.py such that we're still using SQLite by default (so there should be no change locally for you both) but one can set DATABASE_URL to change that to Postgres.

However, I'm potentially missing something with "downgrading" the SQLite driver to the stdlib one?