### PR TITLE
Validate CSVs

### DIFF
--- a/codelists/forms.py
+++ b/codelists/forms.py
@@ -1,3 +1,6 @@
+import csv
+from io import StringIO
+
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit
 from django import forms
@@ -42,7 +45,27 @@ class SignOffForm(forms.ModelForm):
         ]
 
 
-class CodelistForm(forms.ModelForm):
+class CSVValidationMixin:
+    def clean_csv_data(self):
+        data = self.cleaned_data["csv_data"].read().decode("utf-8")
+
+        reader = csv.reader(StringIO(data))
+        num_columns = len(next(reader))  # expected to be headers
+        errors = [i for i, row in enumerate(reader) if len(row) != num_columns]
+
+        if errors:
+            msg = "Incorrect number of columns on row {}"
+            raise forms.ValidationError(
+                [
+                    forms.ValidationError(msg.format(i + 1), code=f"row{i + 1}")
+                    for i in errors
+                ]
+            )
+
+        return data
+
+
+class CodelistForm(forms.ModelForm, CSVValidationMixin):
     csv_data = forms.FileField(label="CSV data")
 
     class Meta:
@@ -55,7 +78,7 @@ class CodelistForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
 
 
-class CodelistVersionForm(forms.Form):
+class CodelistVersionForm(forms.Form, CSVValidationMixin):
     csv_data = forms.FileField(label="CSV data")
 
     class Meta:

--- a/codelists/models.py
+++ b/codelists/models.py
@@ -70,7 +70,7 @@ class CodelistVersion(models.Model):
 
     def get_absolute_url(self):
         return reverse(
-            "codelists:version",
+            "codelists:version-detail",
             args=(
                 self.codelist.project_id,
                 self.codelist.slug,

--- a/codelists/tests/helpers.py
+++ b/codelists/tests/helpers.py
@@ -1,4 +1,19 @@
+from io import BytesIO
+
 from codelists import tree_utils
+
+
+def csv_builder(contents):
+    """
+    Build a CSV from the given contents
+
+    When testing CSVs in views and forms we need to replicate an uploaded CSV,
+    this does that with the use of BytesIO.
+    """
+    buffer = BytesIO()
+    buffer.write(contents.encode("utf8"))
+    buffer.seek(0)
+    return buffer
 
 
 def build_tree(depth=4):

--- a/codelists/tests/test_forms.py
+++ b/codelists/tests/test_forms.py
@@ -1,0 +1,39 @@
+import pytest
+from django.core.exceptions import ValidationError
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from codelists.forms import CSVValidationMixin
+
+from .helpers import csv_builder
+
+
+def test_csvvalidation_correct_csv_column_count():
+    form = CSVValidationMixin()
+
+    # wrap CSV up in SimpleUploadedFile to mirror how a Django view would
+    # handle it
+    csv_data = "code,description\n1067731000000107,Injury whilst swimming (disorder)"
+    upload_file = csv_builder(csv_data)
+    uploaded_file = SimpleUploadedFile("our csv", upload_file.read())
+    form.cleaned_data = {"csv_data": uploaded_file}
+
+    assert form.clean_csv_data() == csv_data
+
+
+def test_codelistform_incorrect_csv_column_count():
+    form = CSVValidationMixin()
+
+    # wrap CSV up in SimpleUploadedFile to mirror how a Django view would
+    # handle it
+    csv_data = (
+        "code,description\n1067731000000107,Injury whilst swimming (disorder),test"
+    )
+    upload_file = csv_builder(csv_data)
+    uploaded_file = SimpleUploadedFile("our csv", upload_file.read())
+    form.cleaned_data = {"csv_data": uploaded_file}
+
+    with pytest.raises(ValidationError) as e:
+        form.clean_csv_data()
+
+    assert len(e.value.messages) == 1
+    assert e.value.messages[0] == "Incorrect number of columns on row 1"

--- a/codelists/urls.py
+++ b/codelists/urls.py
@@ -43,9 +43,19 @@ urlpatterns = [
     ),
     path("codelist/<project_slug>/<codelist_slug>/", views.codelist, name="codelist"),
     path(
+        "codelist/<project_slug>/<codelist_slug>/add",
+        views.VersionCreate.as_view(),
+        name="version-create",
+    ),
+    path(
         "codelist/<project_slug>/<codelist_slug>/<qualified_version_str>/",
         views.version,
-        name="version",
+        name="version-detail",
+    ),
+    path(
+        "codelist/<project_slug>/<codelist_slug>/<qualified_version_str>/update/",
+        views.VersionUpdate.as_view(),
+        name="version-update",
     ),
     path(
         "codelist/<project_slug>/<codelist_slug>/<qualified_version_str>/download.csv",

--- a/codelists/views.py
+++ b/codelists/views.py
@@ -73,7 +73,7 @@ class CreateCodelist(TemplateView):
             coding_system_id=form.cleaned_data["coding_system_id"],
             description=form.cleaned_data["description"],
             methodology=form.cleaned_data["methodology"],
-            csv_data=form.cleaned_data["csv_data"].read().decode("utf8"),
+            csv_data=form.cleaned_data["csv_data"],
             references=references,
             signoffs=signoffs,
         )

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load crispy_forms_tags %}
+
 {% load markdown_filter %}
 
 {% block title_extra %}: {{ codelist.name }}{% endblock %}
@@ -39,13 +39,17 @@
     {% if user.is_authenticated %}
     <hr />
     <div class="btn-group-vertical btn-block" role="group">
-      <button type="button" class="btn btn-outline-info btn-block" data-toggle="modal" data-target="#js-create-version-form">
+      <a
+        class="btn btn-outline-info btn-block"
+        href="{% url 'codelists:version-create' project_slug=codelist.project.slug codelist_slug=codelist.slug %}">
         Create new version
-      </button>
+      </a>
       {% if clv.is_draft %}
-      <button type="button" class="btn btn-outline-info btn-block" data-toggle="modal" data-target="#js-update-version-form">
+      <a
+        class="btn btn-outline-info btn-block"
+        href="{% url 'codelists:version-update' project_slug=codelist.project.slug codelist_slug=codelist.slug qualified_version_str=clv.qualified_version_str %}">
         Update version
-      </button>
+      </a>
       {% endif %}
     </div>
     {% endif %}
@@ -206,37 +210,6 @@
   </div>
 </div>
 
-<div class="modal fade" id="js-create-version-form" tabindex="-1" role="dialog" aria-labelledby="create-version-form-label" aria-hidden="true">
-  <div class="modal-dialog" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title" id="create-version-form-label">Create new version</h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
-      </div>
-      <div class="modal-body">
-        {% crispy create_version_form %}
-      </div>
-    </div>
-  </div>
-</div>
-
-<div class="modal fade" id="js-update-version-form" tabindex="-1" role="dialog" aria-labelledby="update-version-form-label" aria-hidden="true">
-  <div class="modal-dialog" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title" id="update-version-form-label">Update version</h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
-      </div>
-      <div class="modal-body">
-        {% crispy update_version_form %}
-      </div>
-    </div>
-  </div>
-</div>
 {% endblock %}
 
 {% block extra_js %}

--- a/templates/codelists/version_create.html
+++ b/templates/codelists/version_create.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+
+{% load crispy_forms_tags %}
+
+{% block content %}
+
+<div class="row my-5">
+  <div class="col-8 offset-2">
+
+    <h3 class="mb-5">Create new Version</h3>
+
+    {% crispy form %}
+
+  </div>
+</div>
+
+{% endblock %}

--- a/templates/codelists/version_update.html
+++ b/templates/codelists/version_update.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+
+{% load crispy_forms_tags %}
+
+{% block content %}
+
+<div class="row my-5">
+  <div class="col-8 offset-2">
+
+    <h3 class="mb-5">
+      Update Version: {{ version.qualified_version_str }}
+    </h3>
+
+    {% crispy form %}
+
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
This validates CSVs uploaded when creating a new CodeList or Version, and when updating an existing Version.  It ensures each row of the CSV has the same number of colmuns as there are headers/columns in the first row.

I chose to split out the Create/Update Version forms into separate views to simplify showing the user errors (I suspect I could have made the modals open on load but I wasn't confident so I went with what I knew!).  So I've cut down the `version` view to no longer handle forms and added `VersionCreate` and `VersionUpdate` to handle them instead.

**Create Version**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/lluYwbqr/Image%202020-08-07%20at%204.48.53%20pm.png?v=7a112960990bebe79abcd4e9168111b9)

**Update Version**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/12uJEmX5/Image%202020-08-07%20at%204.49.17%20pm.png?v=f766163de63c65a27a14614a8a43035e)

Fixes #48 