### PR TITLE
Publish Draft Versions

### DIFF
--- a/codelists/actions.py
+++ b/codelists/actions.py
@@ -81,3 +81,5 @@ def publish_version(*, version):
     assert version.is_draft
     version.is_draft = False
     version.save()
+
+    return version

--- a/codelists/models.py
+++ b/codelists/models.py
@@ -78,6 +78,16 @@ class CodelistVersion(models.Model):
             ),
         )
 
+    def get_publish_url(self):
+        return reverse(
+            "codelists:version-publish",
+            kwargs={
+                "project_slug": self.codelist.project.slug,
+                "codelist_slug": self.codelist.slug,
+                "qualified_version_str": self.qualified_version_str,
+            },
+        )
+
     @cached_property
     def coding_system_id(self):
         return self.codelist.coding_system_id

--- a/codelists/tests/test_views.py
+++ b/codelists/tests/test_views.py
@@ -6,7 +6,12 @@ from django.contrib.auth.models import AnonymousUser
 from django.http import Http404
 from pytest_django.asserts import assertContains, assertRedirects
 
-from codelists.views import CreateCodelist, VersionCreate, VersionUpdate
+from codelists.views import (
+    CreateCodelist,
+    VersionCreate,
+    VersionUpdate,
+    version_publish,
+)
 from opencodelists.tests.factories import ProjectFactory, UserFactory
 
 from . import factories
@@ -275,6 +280,60 @@ def test_versioncreate_unknown_codelist(rf):
         VersionCreate.as_view()(
             request, project_slug=codelist.project.slug, codelist_slug="test",
         )
+
+
+def test_versionpublish_success(rf):
+    version = factories.create_draft_version()
+
+    request = rf.post("/")
+    request.user = UserFactory()
+    response = version_publish(
+        request,
+        project_slug=version.codelist.project.slug,
+        codelist_slug=version.codelist.slug,
+        qualified_version_str=version.qualified_version_str,
+    )
+
+    assert response.status_code == 302
+
+    version.refresh_from_db()
+
+    assert response.url == version.get_absolute_url()
+    assert not version.is_draft
+
+
+def test_versionpublish_unknown_version(rf):
+    codelist = factories.create_codelist()
+
+    request = rf.post("/")
+    request.user = UserFactory()
+    with pytest.raises(Http404):
+        version_publish(
+            request,
+            project_slug=codelist.project.slug,
+            codelist_slug=codelist.slug,
+            qualified_version_str="test",
+        )
+
+
+def test_versionpublish_draft_mismatch(rf):
+    version = factories.create_published_version()
+
+    # set the version string to that of a draft
+    qualified_version_str = f"{version.qualified_version_str}-draft"
+
+    request = rf.post("/")
+    request.user = UserFactory()
+    response = version_publish(
+        request,
+        project_slug=version.codelist.project.slug,
+        codelist_slug=version.codelist.slug,
+        qualified_version_str=qualified_version_str,
+    )
+
+    # we should get redirected to the Version page
+    assert response.status_code == 302
+    assert response.url == version.get_absolute_url()
 
 
 def test_versionupdate_unknown_version(rf):

--- a/codelists/tests/test_views.py
+++ b/codelists/tests/test_views.py
@@ -12,7 +12,13 @@ from opencodelists.tests.factories import ProjectFactory, UserFactory
 from . import factories
 from .helpers import csv_builder
 
-pytestmark = pytest.mark.freeze_time("2020-07-23")
+pytestmark = [
+    pytest.mark.freeze_time("2020-07-23"),
+    pytest.mark.filterwarnings(
+        "ignore::DeprecationWarning:bleach",
+        "ignore::django.utils.deprecation.RemovedInDjango40Warning:debug_toolbar",
+    ),
+]
 
 
 @pytest.fixture()

--- a/codelists/urls.py
+++ b/codelists/urls.py
@@ -53,6 +53,11 @@ urlpatterns = [
         name="version-detail",
     ),
     path(
+        "codelist/<project_slug>/<codelist_slug>/<qualified_version_str>/publish/",
+        views.version_publish,
+        name="version-publish",
+    ),
+    path(
         "codelist/<project_slug>/<codelist_slug>/<qualified_version_str>/update/",
         views.VersionUpdate.as_view(),
         name="version-update",

--- a/codelists/views.py
+++ b/codelists/views.py
@@ -215,7 +215,7 @@ def version_publish(request, project_slug, codelist_slug, qualified_version_str)
     if expect_draft != version.is_draft:
         return redirect(version)
 
-    actions.publish_version(version=version)
+    version = actions.publish_version(version=version)
 
     return redirect(version)
 

--- a/codelists/views.py
+++ b/codelists/views.py
@@ -215,6 +215,10 @@ def version_publish(request, project_slug, codelist_slug, qualified_version_str)
     if expect_draft != version.is_draft:
         return redirect(version)
 
+    # We want to redirect to the now-published Version after publishing it, but
+    # the in-memory instance in this view won't be updated by the .save() call
+    # inside the action.  So instead we return the new instance from the action
+    # and use that.
     version = actions.publish_version(version=version)
 
     return redirect(version)

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -50,6 +50,15 @@
         href="{% url 'codelists:version-update' project_slug=codelist.project.slug codelist_slug=codelist.slug qualified_version_str=clv.qualified_version_str %}">
         Update version
       </a>
+      {% if clv.is_draft %}
+      <button
+        type="button"
+        class="btn btn-outline-info btn-block"
+        data-toggle="modal"
+        data-target="#js-publish-version-form">
+        Publish version
+      </button>
+      {% endif %}
       {% endif %}
     </div>
     {% endif %}
@@ -206,6 +215,36 @@
       {{ html_tree|safe }}
       </div>
       {% endif %}
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="js-publish-version-form" tabindex="-1" role="dialog" aria-labelledby="publish-version-label" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+
+        <h5 class="modal-title" id="publish-version-label">Publish Version</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+
+      </div>
+      <div class="modal-body">
+
+        <form method="POST" action="{{ clv.get_publish_url }}">
+          {% csrf_token %}
+
+          <p>Are you sure you want to publish this version?</p>
+
+          <div class="d-flex justify-content-between">
+            <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+            <button type="submit" class="btn btn-primary">Publish</button>
+          </div>
+
+        </form>
+
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This adds a new button to the LHN controls:

![](https://p198.p4.n0.cdn.getcloudapp.com/items/8LuPwEnm/Image%202020-08-10%20at%2011.56.58%20am.png?v=9bc83b9c200d9f0378627807ba9c8c8a)

Pops up a modal when clicking this button:

![](https://p198.p4.n0.cdn.getcloudapp.com/items/NQurvmKJ/Image%202020-08-10%20at%2011.57.19%20am.png?v=8e4dd0192eeae0f409b45763d20c2c6c)

And calls the appropriate action to publish the given Version.

The final commit returns the mutated Version to make redirecting to it cleaner.

Note: the first commit removes some noise from the tests output but is expected to not affect deprecations raised by our code calling deprecated APIs.

Fixes #50 