### PR TITLE
Add Test Coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ environment
 tmp
 venv
 __pycache__/
+.coverage
 .hypothesis
+htmlcov

--- a/Makefile
+++ b/Makefile
@@ -48,4 +48,9 @@ sort:
 
 .PHONY: test
 test:
-	python manage.py test
+	pytest \
+		--cov=builder \
+		--cov=codelists \
+		--cov=coding_systems \
+		--cov=mappings \
+		--cov=opencodelists \

--- a/builder/apps.py
+++ b/builder/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class BuilderConfig(AppConfig):
-    name = "builder"

--- a/codelists/apps.py
+++ b/codelists/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class CodelistsConfig(AppConfig):
-    name = "codelists"

--- a/codelists/tests/test_views.py
+++ b/codelists/tests/test_views.py
@@ -28,13 +28,6 @@ pytestmark = [
 ]
 
 
-@pytest.fixture()
-def logged_in_client(client, django_user_model):
-    """A Django test client logged in a user."""
-    client.force_login(UserFactory())
-    return client
-
-
 def test_codelistcreate_success(rf):
     project = ProjectFactory()
     signoff_user = UserFactory()

--- a/coding_systems/bnf/apps.py
+++ b/coding_systems/bnf/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class BnfConfig(AppConfig):
-    name = "bnf"

--- a/coding_systems/ctv3/apps.py
+++ b/coding_systems/ctv3/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class Ctv3Config(AppConfig):
-    name = "ctv3"

--- a/coding_systems/readv2/apps.py
+++ b/coding_systems/readv2/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class Readv2Config(AppConfig):
-    name = "readv2"

--- a/coding_systems/snomedct/apps.py
+++ b/coding_systems/snomedct/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class SnomedctConfig(AppConfig):
-    name = "snomedct"

--- a/mappings/ctv3sctmap2/apps.py
+++ b/mappings/ctv3sctmap2/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class Rctctv3MapConfig(AppConfig):
-    name = "rctctv3map"

--- a/mappings/rctctv3map/apps.py
+++ b/mappings/rctctv3map/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class Rctctv3MapConfig(AppConfig):
-    name = "rctctv3map"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,4 @@ skip_glob = [".direnv", "*migrations*", "tmp", ".venv"]
 known_third_party = ["crispy_forms", "debug_toolbar", "django", "fabric", "factory", "hypothesis", "pytest", "pytest_django", "sentry_sdk"]
 
 [tool.pytest.ini_options]
-env = [
-    "DJANGO_SETTINGS_MODULE = opencodelists.settings",
-]
+DJANGO_SETTINGS_MODULE = "opencodelists.settings"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,20 @@ exclude = '''
 )
 '''
 
+[tool.coverage.run]
+branch = true
+omit = [
+  "opencodelists/asgi.py",
+  "opencodelists/django_test_runner.py",
+  "opencodelists/settings.py",
+  "opencodelists/wsgi.py",
+]
+
+[tool.coverage.report]
+skip_covered = true
+
+[tool.coverage.html]
+
 [tool.isort]
 force_grid_wrap = 0
 include_trailing_comma = true

--- a/requirements.in
+++ b/requirements.in
@@ -12,6 +12,7 @@ sentry-sdk
 # test
 factory_boy
 hypothesis
+pytest-cov
 pytest-django
 pytest-freezegun
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ cfgv==3.2.0               # via pre-commit
 cli-helpers[styles]==1.2.1  # via litecli
 click==7.1.2              # via black, litecli, pip-tools
 configobj==5.0.6          # via cli-helpers, litecli
+coverage==5.2.1           # via pytest-cov
 cryptography==2.9.2       # via paramiko
 distlib==0.3.1            # via virtualenv
 django-cors-headers==3.4.0  # via -r requirements.in
@@ -55,9 +56,10 @@ pygments==2.6.1           # via cli-helpers, litecli
 pynacl==1.3.0             # via paramiko
 pyparsing==2.4.7          # via packaging
 pysqlite3-binary==0.4.3   # via -r requirements.in
+pytest-cov==2.10.0        # via -r requirements.in
 pytest-django==3.9.0      # via -r requirements.in
 pytest-freezegun==0.4.2   # via -r requirements.in
-pytest==6.0.1             # via pytest-django, pytest-freezegun
+pytest==6.0.1             # via pytest-cov, pytest-django, pytest-freezegun
 python-dateutil==2.8.1    # via faker, freezegun
 pytz==2020.1              # via django
 pyyaml==5.3.1             # via pre-commit


### PR DESCRIPTION
This adds test coverage via pytest-cov/coverage.py.

I've opted to skip some modules which I don't think are currently of interest to us, and removed some which coverage pointed out weren't used (autogenerated `apps.py`s).

I've turned on skipping modules with 100% coverage in reports because seeing the list get smaller is a nice positive achievement and gives you fewer things to read!

I've configured it such that `make test` runs coverage (via the `--cov` flags) so we can have coverage by default (and in CI) but a developer can still run pytest without coverage, which is good for tight feedback loops.