### PR TITLE
Add draft badge to Codelist title

### DIFF
--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -6,7 +6,14 @@
 
 {% block content %}
 <br />
-<h3>{{ codelist.name }}</h3>
+<h3>
+  {{ codelist.name }}
+
+  {% if clv.is_draft %}
+  <span class="badge badge-primary">Draft</span>
+  {% endif %}
+
+</h3>
 <br />
 
 <div class="row">


### PR DESCRIPTION
This adds a draft badge to a Codelist title when the current version is a Draft.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/z8uZ89zl/Image%202020-08-13%20at%2010.03.09%20am.png?v=3e8369bf09c994affb87208cc19e8ab3)

We currently show the draft status of versions in the LHN with a badge but given that list is at the bottom of the LHN and the current version is only flagged by "not being a link" (so black text instead of blue) it's not overly obvious.  This aims to make the draft status of a Version immediately obvious to the User.