### PR TITLE
Warn SNOMED Codelists are Generated

### DIFF
--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -12,9 +12,15 @@
   {% if clv.is_draft %}
   <span class="badge badge-primary">Draft</span>
   {% endif %}
-
 </h3>
 <br />
+
+{% if codelist.coding_system_id == "snomedct" %}
+<div class="alert alert-primary mb-5" role="alert">
+  SNOMED CT codelists have been automatically generated. For more information
+  click <a href="https://github.com/opensafely/documentation/blob/master/snomed.md">here</a>.
+</div>
+{% endif %}
 
 <div class="row">
   <div class="col-md-3 col-lg-2">

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -17,8 +17,9 @@
 
 {% if codelist.coding_system_id == "snomedct" %}
 <div class="alert alert-primary mb-5" role="alert">
-  SNOMED CT codelists have been automatically generated. For more information
-  click <a href="https://github.com/opensafely/documentation/blob/master/snomed.md">here</a>.
+  SNOMED CT codelists have been automatically generated and have not been
+  reviewed for accuracy. For more information click
+  <a href="https://github.com/opensafely/documentation/blob/master/snomed.md">here</a>.
 </div>
 {% endif %}
 


### PR DESCRIPTION
This adds a warning banner on SNOMED Codelists telling users the SNOMED Codelists have been generated.  It links out to the relevant docs for more information.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/z8uZ82md/Image%202020-08-13%20at%2012.00.16%20pm.png?v=f41e684d23ab0a2afb622c9dabe60db0)

Blocked by opensafely/documentation#19

Fixes #98