### PR TITLE
Upsert CTV3 -> SNOMED Mappings

### DIFF
--- a/mappings/ctv3sctmap2/import_data.py
+++ b/mappings/ctv3sctmap2/import_data.py
@@ -1,45 +1,83 @@
 import csv
-import datetime
 import glob
 import os
+import sqlite3
 
-from django.db import transaction
-
-from .models import Mapping
+from django.db import connection as django_connection
 
 
 def import_data(release_dir):
-    def load_records():
-        paths = glob.glob(
-            os.path.join(
-                release_dir,
-                "Mapping Tables",
-                "Updated",
-                "Clinically Assured",
-                "ctv3sctmap2*.txt",
-            )
+    """
+    Import NHSD CTV3 -> SNOMED concept maps
+    """
+    paths = glob.glob(
+        os.path.join(
+            release_dir,
+            "Mapping Tables",
+            "Updated",
+            "Clinically Assured",
+            "ctv3sctmap2*.txt",
         )
-        assert len(paths) == 1
+    )
+    assert len(paths) == 1
 
-        with open(paths[0]) as f:
-            reader = csv.reader(f, delimiter="\t")
-            next(reader)
-            for r in reader:
-                if r[4] == "_DRUG":  # SCT_CONCEPTID
-                    r[4] = None
-                    r[5] = None
-                r[6] = r[6] == "1"  # MAPSTATUS
-                r[7] = parse_date(r[7])  # EFFECTIVEDATE
-                r[8] = r[8] == "1"  # IS_ASSURED
+    with open(paths[0]) as f:
+        reader = csv.DictReader(f, delimiter="\t")
 
-                if not r[6]:
-                    continue
-                yield r
+        values = list(iter_values(reader))
 
-    with transaction.atomic():
-        Mapping.objects.all().delete()
-        Mapping.objects.bulk_create(Mapping(*r) for r in load_records())
+    # UPSERT rows based on ID, using effective date to decide if a row should
+    # overwrite an existing one.
+    query = """
+    INSERT INTO ctv3sctmap2_mapping(
+        id,
+        ctv3_concept_id,
+        ctv3_term_id,
+        ctv3_term_type,
+        sct_concept_id,
+        sct_description_id,
+        map_status,
+        effective_date,
+        is_assured)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(id) DO UPDATE SET
+      map_status=excluded.map_status,
+      effective_date=excluded.effective_date,
+      is_assured=excluded.is_assured
+    WHERE excluded.effective_date > ctv3sctmap2_mapping.effective_date;
+    """
+
+    # execute the query above for each row from the release data
+    connection_params = django_connection.get_connection_params()
+    connection = sqlite3.connect(**connection_params)
+    connection.executemany(query, values)
+    connection.commit()
+    connection.close()
 
 
-def parse_date(datestr):
-    return datetime.date(int(datestr[:4]), int(datestr[4:6]), int(datestr[6:]))
+def iter_values(rows):
+    """
+    Convert the given rows into an iterable of values for upserting to the DB.
+    """
+    for r in rows:
+        # ignore SNOMED Concept and Description IDs when the Concept ID is _DRUG
+        sct_concept = r["SCT_CONCEPTID"] if r["SCT_CONCEPTID"] != "_DRUG" else None
+        sct_description = (
+            r["SCT_DESCRIPTIONID"] if r["SCT_CONCEPTID"] != "_DRUG" else None
+        )
+
+        yield [
+            r["MAPID"].strip("{}-"),
+            r["CTV3_CONCEPTID"],
+            r["CTV3_TERMID"],
+            r["CTV3_TERMTYPE"],
+            sct_concept,
+            sct_description,
+            r["MAPSTATUS"] == "1",
+            parse_date(r["EFFECTIVEDATE"]),
+            r["IS_ASSURED"] == "1",
+        ]
+
+
+def parse_date(s):
+    return "-".join([s[:4], s[4:6], s[6:]])

--- a/mappings/ctv3sctmap2/models.py
+++ b/mappings/ctv3sctmap2/models.py
@@ -2,6 +2,16 @@ from django.db import models
 
 
 class Mapping(models.Model):
+    """
+    Mappings between CTV3 and SNOMED Concepts.
+
+    NHS Digital has published mappings between Concepts in the CTV3 and SNOMED
+    coding systems [1].  We ingest those mappings and store them with this
+    model.
+
+    1: https://isd.digital.nhs.uk/trud3/user/authenticated/group/0/pack/8/subpack/9/releases
+    """
+
     id = models.UUIDField(primary_key=True)
     ctv3_concept = models.ForeignKey(
         "ctv3.Concept",


### PR DESCRIPTION
This changes how we import CTV3 -> SNOMED mapping records.  The mapping file includes deactivated maps so instead of only ingesting active maps we need to consider those as well.  Rows in this file with the same Map ID are disambiguated using the Effective Date field (eg we only need to care about the latest version of any Map ID).  This uses an UPSERT query to handle this.

As a nice unintended bonus ingesting is now ~2x fast.