### PR TITLE
Add Logging

### DIFF
--- a/deploy/gunicorn/conf.py
+++ b/deploy/gunicorn/conf.py
@@ -1,3 +1,13 @@
+from services.logging import logging_config_dict
+
 bind = "unix:/tmp/gunicorn-opencodelists.sock"
 workers = 2
 timeout = 30
+
+# Where to log to (stdout and stderr)
+accesslog = "-"
+errorlog = "-"
+
+# Configure log structure
+# http://docs.gunicorn.org/en/stable/settings.html#logconfig-dict
+logconfig_dict = logging_config_dict

--- a/opencodelists/actions.py
+++ b/opencodelists/actions.py
@@ -1,11 +1,22 @@
+import structlog
+
 from .models import Organisation, Project
+
+logger = structlog.get_logger()
 
 
 def create_organisation(*, name, url):
-    return Organisation.objects.create(name=name, url=url)
+    org = Organisation.objects.create(name=name, url=url)
+
+    logger.info("Created Organisation", organisation_pk=org.pk)
+
+    return org
 
 
 def create_project(*, name, url, details, organisations):
     p = Project.objects.create(name=name, url=url, details=details)
     p.organisations.set(organisations)
+
+    logger.info("Created Project", project_pk=p.pk)
+
     return p

--- a/opencodelists/settings.py
+++ b/opencodelists/settings.py
@@ -9,13 +9,13 @@ https://docs.djangoproject.com/en/3.0/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.0/ref/settings/
 """
-
-
 import os
 import sys
 
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
+
+from services.logging import logging_config_dict
 
 # Patch sqlite3 to ensure recent version
 __import__("pysqlite3")
@@ -80,6 +80,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "debug_toolbar.middleware.DebugToolbarMiddleware",
+    "django_structlog.middlewares.RequestMiddleware",
 ]
 
 ROOT_URLCONF = "opencodelists.urls"
@@ -156,34 +157,7 @@ WHITENOISE_USE_FINDERS = True
 
 
 # Logging
-
-# fmt: off
-LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "handlers": {
-        "console": {
-            "class": "logging.StreamHandler",
-        },
-    },
-    "root": {
-        "handlers": ["console"],
-        "level": "WARNING",
-    },
-    "loggers": {
-        "django": {
-            "handlers": ["console"],
-            "level": os.getenv("DJANGO_LOG_LEVEL", "INFO"),
-            "propagate": False,
-        },
-        "django.db.backends": {
-            "handlers": ["console"],
-            "level": "DEBUG" if os.getenv("DJANGO_LOG_DB") else "INFO",
-            "propagate": False,
-        },
-    },
-}
-# fmt: on
+LOGGING = logging_config_dict
 
 
 # Tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ line_length = 88
 multi_line_output = 3
 use_parentheses = true
 skip_glob = [".direnv", "*migrations*", "tmp", ".venv"]
-known_third_party = ["crispy_forms", "debug_toolbar", "django", "fabric", "factory", "hypothesis", "pytest", "pytest_django", "sentry_sdk"]
+known_third_party = ["crispy_forms", "debug_toolbar", "django", "fabric", "factory", "hypothesis", "pytest", "pytest_django", "sentry_sdk", "structlog"]
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "opencodelists.settings"

--- a/requirements.in
+++ b/requirements.in
@@ -4,10 +4,12 @@ django-crispy-forms
 django-cors-headers
 django-debug-toolbar
 django-markdown-filter
+django-structlog
 gunicorn
 pysqlite3-binary
 whitenoise
 sentry-sdk
+structlog
 
 # test
 factory_boy

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,8 +23,10 @@ django-cors-headers==3.4.0  # via -r requirements.in
 django-crispy-forms==1.9.2  # via -r requirements.in
 django-debug-toolbar==2.2  # via -r requirements.in
 django-extensions==3.0.5  # via -r requirements.in
+django-ipware==3.0.1      # via django-structlog
 django-markdown-filter==0.0.1  # via -r requirements.in
-django==3.1               # via -r requirements.in, django-cors-headers, django-debug-toolbar, django-markdown-filter
+django-structlog==1.6.1   # via -r requirements.in
+django==3.1               # via -r requirements.in, django-cors-headers, django-debug-toolbar, django-markdown-filter, django-structlog
 fabric3==1.14.post1       # via -r requirements.in
 factory-boy==3.0.1        # via -r requirements.in
 faker==4.1.1              # via factory-boy
@@ -65,9 +67,10 @@ pytz==2020.1              # via django
 pyyaml==5.3.1             # via pre-commit
 regex==2020.4.4           # via black
 sentry-sdk==0.17.0        # via -r requirements.in
-six==1.14.0               # via bcrypt, bleach, configobj, cryptography, fabric3, freezegun, packaging, pip-tools, pynacl, python-dateutil, virtualenv
+six==1.14.0               # via bcrypt, bleach, configobj, cryptography, fabric3, freezegun, packaging, pip-tools, pynacl, python-dateutil, structlog, virtualenv
 sortedcontainers==2.1.0   # via hypothesis
 sqlparse==0.3.1           # via django, django-debug-toolbar, litecli
+structlog==20.1.0         # via -r requirements.in, django-structlog
 tabulate[widechars]==0.8.7  # via cli-helpers
 terminaltables==3.1.0     # via cli-helpers
 text-unidecode==1.3       # via faker

--- a/services/logging.py
+++ b/services/logging.py
@@ -1,0 +1,97 @@
+import os
+
+import structlog
+
+# add logging before app has booted
+DEBUG = os.getenv("DEBUG", default=False)
+
+
+def timestamper(logger, log_method, event_dict):
+    """
+    Add timestamps to logs conditionally
+
+    Structlog provides a Timestamper processor.  However, we only want to
+    timestamp logs locally since Production (systemd) stamps logs for us.  This
+    mirrors how the Timestamper processor stamps events internally.
+    """
+    if not DEBUG:
+        return event_dict
+
+    # mirror how structlogs own Timestamper calls _make_stamper
+    stamper = structlog.processors._make_stamper(fmt="iso", utc=True, key="timestamp")
+    return stamper(event_dict)
+
+
+pre_chain = [
+    # Add the log level and a timestamp to the event_dict if the log entry
+    # is not from structlog.
+    structlog.stdlib.add_log_level,
+    structlog.stdlib.add_logger_name,
+    timestamper,
+]
+
+structlog.configure(
+    processors=[
+        structlog.stdlib.filter_by_level,
+        timestamper,
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
+        structlog.processors.UnicodeDecoder(),
+        structlog.processors.ExceptionPrettyPrinter(),
+        structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+    ],
+    context_class=structlog.threadlocal.wrap_dict(dict),
+    logger_factory=structlog.stdlib.LoggerFactory(),
+    wrapper_class=structlog.stdlib.BoundLogger,
+    cache_logger_on_first_use=True,
+)
+
+logging_config_dict = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "formatter": {
+            "()": structlog.stdlib.ProcessorFormatter,
+            "processor": structlog.dev.ConsoleRenderer(colors=DEBUG),
+            "foreign_pre_chain": pre_chain,
+        }
+    },
+    "handlers": {
+        "console": {
+            "level": "DEBUG",
+            "class": "logging.StreamHandler",
+            "formatter": "formatter",
+        }
+    },
+    "root": {"handlers": ["console"], "level": "WARNING"},
+    "loggers": {
+        "django": {
+            "handlers": ["console"],
+            "level": os.getenv("DJANGO_LOG_LEVEL", "INFO"),
+            "propagate": False,
+        },
+        "django.db.backends": {
+            "handlers": ["console"],
+            "level": "DEBUG" if os.getenv("DJANGO_LOG_DB") else "INFO",
+            "propagate": False,
+        },
+        "gunicorn": {"handlers": ["console"], "level": "INFO", "propagate": False},
+        "django_structlog": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        "builder": {"handlers": ["console"], "level": "INFO", "propagate": False},
+        "codelists": {"handlers": ["console"], "level": "INFO", "propagate": False},
+        "coding_systems": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        "mappings": {"handlers": ["console"], "level": "INFO", "propagate": False},
+        "opencodelists": {"handlers": ["console"], "level": "INFO", "propagate": False},
+    },
+}


### PR DESCRIPTION
This adds [more] logging to the project via [Structlog](https://www.structlog.org/en/stable/) and it's Django companion package [django-structlog](https://django-structlog.readthedocs.io/en/latest/index.html).

django-structlog binds request and user IDs to the log context allowing us to emit logs from inside our actions and get this kind of output for submitting the Codelist creation form:

```
2020-08-28T07:41:27.826096Z [info     ] request_started                [django_structlog.middlewares.request] ip=127.0.0.1 request=<WSGIRequest: POST '/codelist/test/'> request_id=d3804098-c2c5-4cd3-8e80-b1e3ee2b94a0 user_agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:80.0) Gecko/20100101 Firefox/80.0 user_id=ghickman
2020-08-28T07:41:27.891123Z [info     ] Codelist created               [codelists.actions] codelist_pk=8 ip=127.0.0.1 request_id=d3804098-c2c5-4cd3-8e80-b1e3ee2b94a0 user_id=ghickman
2020-08-28T07:41:27.891862Z [info     ] request_finished               [django_structlog.middlewares.request] code=302 ip=127.0.0.1 request=<WSGIRequest: POST '/codelist/test/'> request_id=d3804098-c2c5-4cd3-8e80-b1e3ee2b94a0 user_id=ghickman
```

I've configured both Django and Gunicorn to use the new logging config.  This will normalise our logs in production which currently emit different formats for Django vs Gunicorn (with the latter emitting two timestamps).

---

#### Services Package
I've placed the logging configuration into `services/logging.py` to separate it from Django's settings.  I don't typically create a services package until I have something which is _actually_ a service (in the [12 factor app](https://12factor.net/backing-services) sense), but a core reason I abstract those from Django settings is to avoid poluting its global namespace with config for those services.  In this instance it provides two benefits: 
1. I want to configure Gunicorns logs so the config can't be inside Django anyway.
1.  I don't want to add `pre_chain` and `timestamper` as things one can import from `django.conf.settings`.

Of course this is Python and there's nothing to stop someone doing `from services.logging import pre_chain` but the layout aims to keep settings.py simpler without removing access to a user who wants those lower level parts.

I wrote up this pattern as an [Architecture Pattern for Mozilla's Treeherder](https://github.com/mozilla/treeherder/blob/5c849ef3b20f4bb29a9d5a0ceba02460c946f696/docs/arch/adr-001.rst) (the doc didn't get merged for unrelated reasons but the pattern did).