### PR TITLE
Add Definition Presenter

### DIFF
--- a/codelists/definition.py
+++ b/codelists/definition.py
@@ -1,6 +1,3 @@
-from django.urls import reverse
-
-
 class Definition:
     """Represents a set of rules that define a list of codes.  Each rule indicates
     whether a given code is included (an "including rule") or excluded (an "excluding
@@ -201,70 +198,3 @@ class DefinitionRule:
             code_is_excluded=code_is_excluded,
             applies_to_descendants=applies_to_descendants,
         )
-
-
-def build_html_definition(coding_system, hierarchy, definition):
-    """Render a Definition as HTML.
-
-    This code will change significantly in an upcoming commit, when it will have a
-    proper docstring.
-    """
-
-    code_to_name = coding_system.lookup_names([rule.code for rule in definition.rules])
-
-    def name_for_rule(rule):
-        return code_to_name.get(rule.code, "Unknown code (a TPP Y-code?)")
-
-    lines = ["<ul>"]
-
-    for rule in sorted(definition.including_rules(), key=name_for_rule):
-        name = name_for_rule(rule)
-        url = reverse(f"{coding_system.id}:concept", args=[rule.code])
-        style = "color: blue"
-
-        if rule.applies_to_descendants:
-            matching_excluding_rules = [
-                excluding_rule
-                for excluding_rule in definition.excluding_rules()
-                if excluding_rule.code in hierarchy.descendants(rule.code)
-            ]
-
-            if matching_excluding_rules:
-                lines.append(
-                    f'<li><a href="{url}" style="{style}">{name}</a> (<code>{rule.code}</code>) and all descendants except:</li>'
-                )
-                lines.append('<ul class="mb-0">')
-
-                for excluding_rule in sorted(
-                    matching_excluding_rules, key=name_for_rule
-                ):
-                    name = name_for_rule(excluding_rule)
-                    url = reverse(
-                        f"{coding_system.id}:concept", args=[excluding_rule.code]
-                    )
-                    style = "color: black"
-
-                    if excluding_rule.applies_to_descendants:
-                        lines.append(
-                            f'<li><a href="{url}" style="{style}">{name}</a> (<code>{excluding_rule.code}</code>) and all descendants</li>'
-                        )
-                    else:
-                        lines.append(
-                            f'<li><a href="{url}" style="{style}">{name}</a> (<code>{excluding_rule.code}</code>)</li>'
-                        )
-
-                lines.append("</ul>")
-
-            else:
-                lines.append(
-                    f'<li><a href="{url}" style="{style}">{name}</a> (<code>{rule.code}</code>) and all descendants</li>'
-                )
-
-        else:
-            lines.append(
-                f'<li><a href="{url}" style="{style}">{name}</a> (<code>{rule.code}</code>)</li>'
-            )
-
-    lines.append("</ul>")
-
-    return "\n".join(lines)

--- a/codelists/definition.py
+++ b/codelists/definition.py
@@ -147,6 +147,18 @@ class DefinitionRule:
     """
 
     def __init__(self, code, code_is_excluded=False, applies_to_descendants=False):
+        # Shout loudly if assumptions in Definition.from_codes changes.  Other
+        # parts of the system (DefinitionRow as of writing this) rely on the
+        # following behaviour.  While this behaviour could change, and this
+        # check shouldn't stop that, we want to know (loudly!) if it changes
+        # implicitly.
+        if code_is_excluded and applies_to_descendants:
+            msg = (
+                "Tried to set both code_is_excluded and applies_to_descendants for "
+                f"code={code}.  A DefinitionRule cannot have both of these set."
+            )
+            raise TypeError(msg)
+
         self.code = code
         self.code_is_excluded = code_is_excluded
         self.applies_to_descendants = applies_to_descendants

--- a/codelists/presenters.py
+++ b/codelists/presenters.py
@@ -29,7 +29,7 @@ class DefinitionRow:
     all_descendants: bool = attr.ib(default=True)
 
 
-def _iter_rules(hierarchy, rules, name_for_rule, excluded=None):
+def _iter_rules(hierarchy, rules, name_for_rule, excluded):
     for rule in rules:
         row = DefinitionRow(
             name=name_for_rule(rule),
@@ -48,9 +48,14 @@ def _iter_rules(hierarchy, rules, name_for_rule, excluded=None):
         ]
 
         # generate excluded children by recursing into this function
-        row.excluded_descendants = list(
-            _iter_rules(hierarchy, excluding_rules, name_for_rule)
-        )
+        row.excluded_descendants = [
+            DefinitionRow(
+                name=name_for_rule(rule),
+                code=rule.code,
+                all_descendants=rule.applies_to_descendants,
+            )
+            for rule in excluding_rules
+        ]
 
         yield attr.asdict(row)
 

--- a/codelists/presenters.py
+++ b/codelists/presenters.py
@@ -5,33 +5,33 @@ from django.urls import reverse
 
 
 @attr.s
-class Row:
+class DefinitionRow:
     """
     Data structure for a Definition to prepare for display
 
     name: name of the definition
     code: code of the definition
-    excluded_children: list of excluded children (created with this class too)
+    excluded_descendants: list of excluded children (created with this class too)
     all_descendants: are all of this Definitions descendants included?
 
-    Between all_descendants and excluded_children we can cover the three state
-    situation a Definition can be in:
+    Between all_descendants and excluded_descendants we can cover the three state
+    situation a DefinitionRow can be in:
 
-        * all descendants are included (all_descendants = True, excluded_children = [])
-        * all descendants except N (all_descendants = True, excluded_children = [...])
-        * no descendants (all_descendants = False, excluded_children ignored)
+        * all descendants are included (all_descendants = True, excluded_descendants = [])
+        * all descendants except N (all_descendants = True, excluded_descendants = [...])
+        * no descendants (all_descendants = False, excluded_descendants ignored)
 
     """
 
     name: str = attr.ib()
     code: str = attr.ib()
-    excluded_children: list = attr.ib(default=list())
+    excluded_descendants: list = attr.ib(default=list())
     all_descendants: bool = attr.ib(default=True)
 
 
 def _iter_rules(hierarchy, rules, name_for_rule, excluded=None):
     for rule in rules:
-        row = Row(
+        row = DefinitionRow(
             name=name_for_rule(rule),
             code=rule.code,
             all_descendants=rule.applies_to_descendants,
@@ -48,7 +48,7 @@ def _iter_rules(hierarchy, rules, name_for_rule, excluded=None):
         ]
 
         # generate excluded children by recursing into this function
-        row.excluded_children = list(
+        row.excluded_descendants = list(
             _iter_rules(hierarchy, excluding_rules, name_for_rule)
         )
 

--- a/codelists/presenters.py
+++ b/codelists/presenters.py
@@ -1,6 +1,70 @@
 from itertools import groupby
 
+import attr
 from django.urls import reverse
+
+
+@attr.s
+class Row:
+    """
+    Data structure for a Definition to prepare for display
+
+    name: name of the definition
+    code: code of the definition
+    excluded_children: list of excluded children (created with this class too)
+    all_descendants: are all of this Definitions descendants included?
+
+    Between all_descendants and excluded_children we can cover the three state
+    situation a Definition can be in:
+
+        * all descendants are included (all_descendants = True, excluded_children = [])
+        * all descendants except N (all_descendants = True, excluded_children = [...])
+        * no descendants (all_descendants = False, excluded_children ignored)
+
+    """
+
+    name: str = attr.ib()
+    code: str = attr.ib()
+    excluded_children: list = attr.ib(default=list())
+    all_descendants: bool = attr.ib(default=True)
+
+
+def _iter_rules(hierarchy, rules, name_for_rule, excluded=None):
+    for rule in rules:
+        row = Row(
+            name=name_for_rule(rule),
+            code=rule.code,
+            all_descendants=rule.applies_to_descendants,
+        )
+
+        # no descendents for this code so we can shortcut the iteration here
+        if not rule.applies_to_descendants:
+            yield attr.asdict(row)
+            continue
+
+        # filter the excluded rules down to children of the current Rule
+        excluding_rules = [
+            r for r in excluded if r.code in hierarchy.descendants(rule.code)
+        ]
+
+        # generate excluded children by recursing into this function
+        row.excluded_children = list(
+            _iter_rules(hierarchy, excluding_rules, name_for_rule)
+        )
+
+        yield attr.asdict(row)
+
+
+def build_definition_rows(coding_system, hierarchy, definition):
+    code_to_name = coding_system.lookup_names([rule.code for rule in definition.rules])
+
+    def name_for_rule(rule):
+        return code_to_name.get(rule.code, "Unknown code (a TPP Y-code?)")
+
+    included_rules = sorted(definition.including_rules(), key=name_for_rule)
+    excluded_rules = sorted(definition.excluding_rules(), key=name_for_rule)
+
+    return list(_iter_rules(hierarchy, included_rules, name_for_rule, excluded_rules))
 
 
 def build_html_tree_highlighting_codes(coding_system, hierarchy, definition):

--- a/codelists/templatetags/definitions.py
+++ b/codelists/templatetags/definitions.py
@@ -1,0 +1,9 @@
+from django import template
+from django.urls import reverse
+
+register = template.Library()
+
+
+@register.simple_tag
+def concept_url(coding_system_id, code):
+    return reverse(f"{coding_system_id}:concept", args=[code])

--- a/codelists/tests/test_definition.py
+++ b/codelists/tests/test_definition.py
@@ -1,7 +1,8 @@
+import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
-from codelists.definition import Definition
+from codelists.definition import Definition, DefinitionRule
 from codelists.hierarchy import Hierarchy
 
 
@@ -87,3 +88,8 @@ def test_roundtrip(hierarchy, codes, r):
 
     definition_codes = [rule.code for rule in definition.rules]
     assert len(definition_codes) == len(set(definition_codes))
+
+
+def test_definition_rule():
+    with pytest.raises(TypeError):
+        DefinitionRule("test", code_is_excluded=True, applies_to_descendants=True)

--- a/codelists/tests/test_presenters.py
+++ b/codelists/tests/test_presenters.py
@@ -66,8 +66,8 @@ def test_build_definition_rows():
     assert row["all_descendants"]
 
     # the only excluded code should be 8
-    assert len(row["excluded_children"]) == 1
-    excluded = row["excluded_children"][0]
+    assert len(row["excluded_descendants"]) == 1
+    excluded = row["excluded_descendants"][0]
     assert excluded["code"] == "8"
 
 

--- a/codelists/tests/test_presenters.py
+++ b/codelists/tests/test_presenters.py
@@ -18,6 +18,59 @@ pytestmark = [
 ]
 
 
+class DummyCodingSystem:
+    def lookup_names(self, names):
+        return {name: name for name in names}
+
+
+def test_build_definition_rows():
+    # hierarchy has this structure:
+    #
+    #      ┌--0--┐
+    #      |     |
+    #   ┌--1--┌--2--┐
+    #   |     |     |
+    # ┌-3-┐ ┌-4-┐ ┌-5-┐
+    # |   | |   | |   |
+    # 6   7 8   9 10 11
+
+    edges = [
+        ("0", "1"),
+        ("0", "2"),
+        ("1", "3"),
+        ("1", "4"),
+        ("2", "4"),
+        ("2", "5"),
+        ("3", "6"),
+        ("3", "7"),
+        ("4", "8"),
+        ("4", "9"),
+        ("5", "10"),
+        ("5", "11"),
+    ]
+    hierarchy = Hierarchy("0", edges)
+
+    # construct a hierarchy with 2, and all its descendants except 8
+    definition = Definition.from_codes({"2", "4", "5", "9", "10", "11"}, hierarchy)
+
+    # make a dummy coding system so we can do name lookup
+    dummy_coding_system = DummyCodingSystem()
+
+    rows = presenters.build_definition_rows(dummy_coding_system, hierarchy, definition)
+
+    # we expect only one row (with an exclusion for 8)
+    assert len(rows) == 1
+
+    row = rows[0]
+    assert row["code"] == "2"
+    assert row["all_descendants"]
+
+    # the only excluded code should be 8
+    assert len(row["excluded_children"]) == 1
+    excluded = row["excluded_children"][0]
+    assert excluded["code"] == "8"
+
+
 def test_build_html_tree_highlighting_codes():
     fixtures_path = Path(settings.BASE_DIR, "coding_systems", "snomedct", "fixtures")
     call_command("loaddata", fixtures_path / "core-model-components.json")

--- a/codelists/views.py
+++ b/codelists/views.py
@@ -12,7 +12,7 @@ from opencodelists.models import Project
 
 from . import actions
 from .coding_systems import CODING_SYSTEMS
-from .definition import Definition, build_html_definition
+from .definition import Definition
 from .forms import (
     CodelistCreateForm,
     CodelistUpdateForm,
@@ -24,7 +24,7 @@ from .forms import (
 )
 from .hierarchy import Hierarchy
 from .models import Codelist, CodelistVersion
-from .presenters import build_html_tree_highlighting_codes
+from .presenters import build_definition_rows, build_html_tree_highlighting_codes
 
 
 def index(request):
@@ -288,7 +288,7 @@ def version(request, project_slug, codelist_slug, qualified_version_str):
 
     headers, *rows = clv.table
 
-    html_definition = None
+    definition_rows = []
     html_tree = None
     if clv.coding_system_id in ["ctv3", "ctv3tpp", "snomedct"]:
         if clv.coding_system_id in ["ctv3", "ctv3tpp"]:
@@ -297,7 +297,7 @@ def version(request, project_slug, codelist_slug, qualified_version_str):
             coding_system = CODING_SYSTEMS["snomedct"]
         hierarchy = Hierarchy.from_codes(coding_system, clv.codes)
         definition = Definition.from_codes(set(clv.codes), hierarchy)
-        html_definition = build_html_definition(coding_system, hierarchy, definition)
+        definition_rows = build_definition_rows(coding_system, hierarchy, definition)
 
         if clv.coding_system_id in ["ctv3", "ctv3tpp"]:
             html_tree = build_html_tree_highlighting_codes(
@@ -311,7 +311,7 @@ def version(request, project_slug, codelist_slug, qualified_version_str):
         "headers": headers,
         "rows": rows,
         "html_tree": html_tree,
-        "html_definition": html_definition,
+        "definition": definition_rows,
     }
     return render(request, "codelists/version.html", ctx)
 

--- a/codelists/views.py
+++ b/codelists/views.py
@@ -311,7 +311,7 @@ def version(request, project_slug, codelist_slug, qualified_version_str):
         "headers": headers,
         "rows": rows,
         "html_tree": html_tree,
-        "definition": definition_rows,
+        "definition_rows": definition_rows,
     }
     return render(request, "codelists/version.html", ctx)
 

--- a/codelists/views.py
+++ b/codelists/views.py
@@ -288,6 +288,8 @@ def version(request, project_slug, codelist_slug, qualified_version_str):
 
     headers, *rows = clv.table
 
+    html_definition = None
+    html_tree = None
     if clv.coding_system_id in ["ctv3", "ctv3tpp", "snomedct"]:
         if clv.coding_system_id in ["ctv3", "ctv3tpp"]:
             coding_system = CODING_SYSTEMS["ctv3"]
@@ -296,15 +298,11 @@ def version(request, project_slug, codelist_slug, qualified_version_str):
         hierarchy = Hierarchy.from_codes(coding_system, clv.codes)
         definition = Definition.from_codes(set(clv.codes), hierarchy)
         html_definition = build_html_definition(coding_system, hierarchy, definition)
+
         if clv.coding_system_id in ["ctv3", "ctv3tpp"]:
             html_tree = build_html_tree_highlighting_codes(
                 coding_system, hierarchy, definition
             )
-        else:
-            html_tree = None
-    else:
-        html_definition = None
-        html_tree = None
 
     ctx = {
         "clv": clv,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ line_length = 88
 multi_line_output = 3
 use_parentheses = true
 skip_glob = [".direnv", "*migrations*", "tmp", ".venv"]
-known_third_party = ["crispy_forms", "debug_toolbar", "django", "fabric", "factory", "hypothesis", "pytest", "pytest_django", "sentry_sdk", "structlog"]
+known_third_party = ["attr", "crispy_forms", "debug_toolbar", "django", "fabric", "factory", "hypothesis", "pytest", "pytest_django", "sentry_sdk", "structlog"]
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "opencodelists.settings"

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -125,7 +125,7 @@
           >About</a
         >
       </li>
-      {% if definition %}
+      {% if definition_rows %}
       <li class="nav-item">
         <a
           class="nav-link"
@@ -205,7 +205,7 @@
         </ul>
       </div>
 
-      {% if definition %}
+      {% if definition_rows %}
       <div
         class="tab-pane fade p-4"
         id="definition"
@@ -219,7 +219,7 @@
         rules that define the codelist.
       </p>
       <ul>
-        {% for row in definition %}
+        {% for row in definition_rows %}
         <li>
           <a href="{% concept_url codelist.coding_system_id row.code %}" style="color: blue">
             {{ row.name }}

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 
+{% load definitions %}
 {% load markdown_filter %}
 
 {% block title_extra %}: {{ codelist.name }}{% endblock %}
@@ -124,7 +125,7 @@
           >About</a
         >
       </li>
-      {% if html_definition %}
+      {% if definition %}
       <li class="nav-item">
         <a
           class="nav-link"
@@ -204,7 +205,7 @@
         </ul>
       </div>
 
-      {% if html_definition %}
+      {% if definition %}
       <div
         class="tab-pane fade p-4"
         id="definition"
@@ -217,7 +218,37 @@
         <a href="#full-list">full codelist</a> and converting it to a list of
         rules that define the codelist.
       </p>
-      {{ html_definition|safe }}
+      <ul>
+        {% for row in definition %}
+        <li>
+          <a href="{% concept_url codelist.coding_system_id row.code %}" style="color: blue">
+            {{ row.name }}
+          </a>
+          (<code>{{ row.code }}</code>)
+
+          {% if row.all_descendants %}
+          and all descendants {% if row.excluded_children %} except:{% endif %}
+          {% endif %}
+
+          {% if row.excluded_children %}
+          <ul class="mb-0">
+
+            {% for child in row.excluded_children %}
+            <li>
+              <a href="{% concept_url codelist.coding_system_id child.code %}" style="color: black">
+                {{ child.name }}
+              </a>
+              (<code>{{ child.code }}</code>)
+            </li>
+            {% endfor %}
+
+          </ul>
+
+          {% endif %}
+        </li>
+
+        {% endfor %}
+      </ul>
       </div>
       {% endif %}
 


### PR DESCRIPTION
This adds the Definition presentation function.  It converts a given Definition instance into a structure (list of dictionaries) ready for display in a template.  The template is now in charge of styling rows of a Definition.

This is a rebuild of #110 on top of @inglesp's new `Hierarchy` object.