### PR TITLE
Ignore Request Logging in Sentry

### DIFF
--- a/opencodelists/settings.py
+++ b/opencodelists/settings.py
@@ -14,6 +14,7 @@ import sys
 
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
+from sentry_sdk.integrations.logging import ignore_logger
 
 from services.logging import logging_config_dict
 
@@ -169,6 +170,9 @@ CRISPY_TEMPLATE_PACK = "bootstrap4"
 
 
 # Sentry
+# ignore the request logging middleware, it creates ungrouped events by default
+# https://docs.sentry.io/platforms/python/guides/logging/#ignoring-a-logger
+ignore_logger("django_structlog.middlewares.request")
 
 SENTRY_DSN = os.environ.get("SENTRY_DSN")
 if SENTRY_DSN:


### PR DESCRIPTION
Sentry [defaults](https://docs.sentry.io/platforms/python/guides/logging/) to picking up logs of `INFO` and above.  django-structlog [logs exceptions](https://github.com/jrobichaud/django-structlog/blob/master/django_structlog/middlewares/request.py#L77-L98) which duplicates the events we already receive.  The events are also ungrouped since the event message contains too many unique parts, giving us a lot of noise.