### PR TITLE
Add Creating Users

### DIFF
--- a/opencodelists/actions.py
+++ b/opencodelists/actions.py
@@ -22,6 +22,16 @@ def create_project(*, name, url, details, organisations):
     return p
 
 
+def activate_user(*, user, password):
+    user.is_active = True
+    user.set_password(password)
+    user.save()
+
+    logger.info("Activated User", user_pk=user.pk)
+
+    return user
+
+
 def create_user(*, username, name, email, organisation, is_active=False):
     user = User.objects.create(
         username=username,

--- a/opencodelists/actions.py
+++ b/opencodelists/actions.py
@@ -1,12 +1,12 @@
 import structlog
 
-from .models import Organisation, Project
+from .models import Organisation, Project, User
 
 logger = structlog.get_logger()
 
 
-def create_organisation(*, name, url):
-    org = Organisation.objects.create(name=name, url=url)
+def create_organisation(*, name, url, slug=None):
+    org = Organisation.objects.create(name=name, url=url, slug=slug)
 
     logger.info("Created Organisation", organisation_pk=org.pk)
 
@@ -20,3 +20,17 @@ def create_project(*, name, url, details, organisations):
     logger.info("Created Project", project_pk=p.pk)
 
     return p
+
+
+def create_user(*, username, name, email, organisation, is_active=False):
+    user = User.objects.create(
+        username=username,
+        name=name,
+        email=email,
+        organisation=organisation,
+        is_active=is_active,
+    )
+
+    logger.info("Created User", user_pk=user.pk)
+
+    return user

--- a/opencodelists/forms.py
+++ b/opencodelists/forms.py
@@ -1,6 +1,7 @@
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit
 from django import forms
+from django.contrib.auth import password_validation
 
 from .models import User
 
@@ -19,3 +20,35 @@ class UserForm(forms.ModelForm):
         self.helper = FormHelper()
         self.helper.add_input(Submit("submit", "Submit"))
         super().__init__(*args, **kwargs)
+
+
+class UserPasswordForm(forms.Form):
+    """
+    A form to let a user set their password without entering their old one.
+
+    This is a reimplementation of Django's contrib.auth.forms.SetPasswordForm
+    to not require a User object be passed in.
+    """
+
+    new_password1 = forms.CharField(
+        widget=forms.PasswordInput(attrs={"autocomplete": "new-password"}),
+        strip=False,
+        help_text=password_validation.password_validators_help_text_html(),
+    )
+    new_password2 = forms.CharField(
+        strip=False,
+        widget=forms.PasswordInput(attrs={"autocomplete": "new-password"}),
+    )
+
+    def clean_new_password2(self):
+        password1 = self.cleaned_data.get("new_password1")
+        password2 = self.cleaned_data.get("new_password2")
+
+        if password1 and password2:
+            if password1 != password2:
+                msg = "The two password fields don't match."
+                raise forms.ValidationError(msg, code="password_mismatch")
+
+        password_validation.validate_password(password2)
+
+        return password2

--- a/opencodelists/forms.py
+++ b/opencodelists/forms.py
@@ -1,0 +1,21 @@
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import Submit
+from django import forms
+
+from .models import User
+
+
+class UserForm(forms.ModelForm):
+    class Meta:
+        fields = [
+            "username",
+            "email",
+            "name",
+            "organisation",
+        ]
+        model = User
+
+    def __init__(self, *args, **kwargs):
+        self.helper = FormHelper()
+        self.helper.add_input(Submit("submit", "Submit"))
+        super().__init__(*args, **kwargs)

--- a/opencodelists/models.py
+++ b/opencodelists/models.py
@@ -1,6 +1,10 @@
 from django.contrib.auth.models import AbstractBaseUser, BaseUserManager
+from django.core.signing import Signer
 from django.db import models
+from django.utils.functional import cached_property
 from django.utils.text import slugify
+
+SET_PASSWORD_SALT = "set-password"
 
 
 class UserManager(BaseUserManager):
@@ -75,6 +79,14 @@ class User(AbstractBaseUser):
 
     def has_module_perms(self, app_label):
         return True
+
+    @cached_property
+    def signed_username(self):
+        return Signer(salt=SET_PASSWORD_SALT).sign(self.username)
+
+    @staticmethod
+    def unsign_username(token):
+        return Signer(salt=SET_PASSWORD_SALT).unsign(token)
 
 
 class Organisation(models.Model):

--- a/opencodelists/models.py
+++ b/opencodelists/models.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.models import AbstractBaseUser, BaseUserManager
 from django.core.signing import Signer
 from django.db import models
+from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.text import slugify
 
@@ -83,6 +84,9 @@ class User(AbstractBaseUser):
     @cached_property
     def signed_username(self):
         return Signer(salt=SET_PASSWORD_SALT).sign(self.username)
+
+    def get_set_password_url(self):
+        return reverse("user-set-password", kwargs={"token": self.signed_username})
 
     @staticmethod
     def unsign_username(token):

--- a/opencodelists/settings.py
+++ b/opencodelists/settings.py
@@ -13,6 +13,7 @@ import os
 import sys
 
 import sentry_sdk
+from django.contrib.messages import constants as messages
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import ignore_logger
 
@@ -210,3 +211,13 @@ LOGOUT_REDIRECT_URL = "/"
 INTERNAL_IPS = [
     "127.0.0.1",
 ]
+
+# Messages
+# https://docs.djangoproject.com/en/3.0/ref/contrib/messages/
+MESSAGE_TAGS = {
+    messages.DEBUG: "alert-info",
+    messages.INFO: "alert-info",
+    messages.SUCCESS: "alert-success",
+    messages.WARNING: "alert-warning",
+    messages.ERROR: "alert-danger",
+}

--- a/opencodelists/tests/test_actions.py
+++ b/opencodelists/tests/test_actions.py
@@ -1,6 +1,16 @@
 from opencodelists import actions
 
-from .factories import OrganisationFactory
+from .factories import OrganisationFactory, UserFactory
+
+
+def test_activate_user():
+    user = UserFactory(is_active=False)
+
+    user = actions.activate_user(user=user, password="test")
+
+    # user has been activated and has a password set
+    assert user.is_active
+    assert user.has_usable_password()
 
 
 def test_create_organisation():

--- a/opencodelists/tests/test_actions.py
+++ b/opencodelists/tests/test_actions.py
@@ -23,3 +23,19 @@ def test_create_project():
     assert p.url == "https://test.org"
     assert p.details == "This is a test"
     assert list(p.organisations.all()) == [o]
+
+
+def test_create_user():
+    org = OrganisationFactory()
+
+    user = actions.create_user(
+        username="testym",
+        name="Testy McTesterson",
+        email="test@example.com",
+        organisation=org,
+    )
+
+    assert user.username == "testym"
+    assert user.name == "Testy McTesterson"
+    assert user.email == "test@example.com"
+    assert user.organisation == org

--- a/opencodelists/tests/test_forms.py
+++ b/opencodelists/tests/test_forms.py
@@ -1,0 +1,19 @@
+import pytest
+from django.core.exceptions import ValidationError
+
+from ..forms import UserPasswordForm
+
+
+def test_userpasswordform_different_passwords():
+    form = UserPasswordForm()
+
+    form.cleaned_data = {
+        "new_password1": "test",
+        "new_password2": "foo",
+    }
+
+    with pytest.raises(ValidationError) as e:
+        form.clean_new_password2()
+
+    assert len(e.value.messages) == 1
+    assert e.value.messages[0] == "The two password fields don't match."

--- a/opencodelists/tests/test_views.py
+++ b/opencodelists/tests/test_views.py
@@ -1,7 +1,9 @@
 import pytest
+from django.contrib.auth import SESSION_KEY
+from django.core.signing import Signer
 
-from ..models import User
-from ..views import UserCreate
+from ..models import SET_PASSWORD_SALT, User
+from ..views import UserCreate, user_set_password
 from .factories import OrganisationFactory, UserFactory
 
 pytestmark = [
@@ -40,3 +42,73 @@ def test_usercreate_creates_user(client):
     assert user.name == "New User"
     assert user.email == "new@example.com"
     assert user.organisation == org
+
+
+def test_usersetpassword_invalid_form(rf):
+    user = UserFactory()
+
+    data = {
+        "new_password1": "test-test-test-1234",
+        "new_password2": "",
+    }
+    request = rf.post("/", data=data)
+    response = user_set_password(request, user.signed_username)
+
+    assert response.status_code == 200
+
+    assert response.context_data["form"].errors
+
+
+def test_usersetpassword_invalid_token(client):
+    response = client.get("/users/activate/test/", follow=True)
+
+    assert response.status_code == 200
+    assert response.redirect_chain[0] == ("/", 302)
+
+    messages = list(response.context["messages"])
+    assert len(messages) == 1
+    assert str(messages[0]) == "Invalid User confirmation URL"
+
+
+def test_usersetpassword_renders_form(rf):
+    user = UserFactory()
+
+    request = rf.get("/")
+    response = user_set_password(request, user.signed_username)
+
+    assert response.status_code == 200
+    assert "form" in response.context_data
+
+
+def test_usersetpassword_success(client):
+    user = UserFactory()
+
+    data = {
+        "new_password1": "test-test-test-1234",
+        "new_password2": "test-test-test-1234",
+    }
+    response = client.post(
+        f"/users/activate/{user.signed_username}/", data=data, follow=True
+    )
+
+    assert response.status_code == 200
+
+    # check user was logged in
+    assert SESSION_KEY in client.session
+    assert client.session[SESSION_KEY] == user.pk
+
+    messages = list(response.context["messages"])
+    assert len(messages) == 1
+    expected = "You have successfully set your password and activated your account"
+    assert str(messages[0]) == expected
+
+
+def test_usersetpassword_unknown_user(client):
+    token = Signer(salt=SET_PASSWORD_SALT).sign("test")
+    response = client.get(f"/users/activate/{token}/", follow=True)
+
+    assert response.status_code == 200
+    assert response.redirect_chain[0] == ("/", 302)
+    messages = list(response.context["messages"])
+    assert len(messages) == 1
+    assert str(messages[0]) == "Unknown User"

--- a/opencodelists/tests/test_views.py
+++ b/opencodelists/tests/test_views.py
@@ -1,0 +1,42 @@
+import pytest
+
+from ..models import User
+from ..views import UserCreate
+from .factories import OrganisationFactory, UserFactory
+
+pytestmark = [
+    pytest.mark.filterwarnings(
+        "ignore::DeprecationWarning:bleach",
+        "ignore::django.utils.deprecation.RemovedInDjango40Warning:debug_toolbar",
+    ),
+]
+
+
+def test_usercreate_renders_form(rf):
+    request = rf.get("/")
+    request.user = UserFactory()
+
+    response = UserCreate.as_view()(request)
+
+    assert response.status_code == 200
+
+
+def test_usercreate_creates_user(client):
+    org = OrganisationFactory(slug="datalab")
+    data = {
+        "username": "new-user",
+        "name": "New User",
+        "email": "new@example.com",
+        "organisation": "datalab",
+    }
+
+    client.force_login(UserFactory())
+    response = client.post("/users/add/", data=data)
+
+    assert response.status_code == 302
+
+    user = User.objects.first()
+    assert user.username == "new-user"
+    assert user.name == "New User"
+    assert user.email == "new@example.com"
+    assert user.organisation == org

--- a/opencodelists/tests/test_views.py
+++ b/opencodelists/tests/test_views.py
@@ -14,6 +14,42 @@ pytestmark = [
 ]
 
 
+def test_useractivationurl_already_active(client):
+    user = UserFactory(is_active=True)
+
+    client.force_login(UserFactory())
+    response = client.get(f"/users/added/{user.username}/", follow=True)
+
+    assert response.status_code == 200
+
+    messages = list(response.context["messages"])
+    assert len(messages) == 1
+    assert str(messages[0]) == f"User '{user.username}' has already been activated."
+
+
+def test_useractivationurl_success(client):
+    user = UserFactory(is_active=False)
+
+    client.force_login(UserFactory())
+    response = client.get(f"/users/added/{user.username}/")
+
+    assert response.status_code == 200
+
+    messages = list(response.context["messages"])
+    assert len(messages) == 0
+
+
+def test_useractivationurl_unknown_user(client):
+    client.force_login(UserFactory())
+    response = client.get("/users/added/foo/", follow=True)
+
+    assert response.status_code == 200
+
+    messages = list(response.context["messages"])
+    assert len(messages) == 1
+    assert str(messages[0]) == "Unknown user 'foo'"
+
+
 def test_usercreate_renders_form(rf):
     request = rf.get("/")
     request.user = UserFactory()

--- a/opencodelists/urls.py
+++ b/opencodelists/urls.py
@@ -5,6 +5,11 @@ from django.urls import include, path
 from . import views
 
 users_patterns = [
+    path(
+        "activate/<token>/",
+        views.user_set_password,
+        name="user-set-password",
+    ),
     path("add/", views.UserCreate.as_view(), name="user-create"),
 ]
 

--- a/opencodelists/urls.py
+++ b/opencodelists/urls.py
@@ -4,8 +4,13 @@ from django.urls import include, path
 
 from . import views
 
+users_patterns = [
+    path("add/", views.UserCreate.as_view(), name="user-create"),
+]
+
 urlpatterns = [
     path("", include("codelists.urls")),
+    path("users/", include(users_patterns)),
     path("admin/", admin.site.urls),
     path("accounts/", include("django.contrib.auth.urls")),
     path("builder/", include("builder.urls")),

--- a/opencodelists/urls.py
+++ b/opencodelists/urls.py
@@ -11,6 +11,11 @@ users_patterns = [
         name="user-set-password",
     ),
     path("add/", views.UserCreate.as_view(), name="user-create"),
+    path(
+        "added/<username>/",
+        views.user_activation_url,
+        name="user-activation-url",
+    ),
 ]
 
 urlpatterns = [

--- a/opencodelists/views.py
+++ b/opencodelists/views.py
@@ -1,9 +1,34 @@
-from django.shortcuts import get_object_or_404, render
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import get_object_or_404, redirect, render
+from django.utils.decorators import method_decorator
+from django.views.generic import CreateView
 
-from .models import Project
+from .actions import create_user
+from .forms import UserForm
+from .models import Project, User
 
 
 def project(request, project_slug):
     project = get_object_or_404(Project, slug=project_slug)
     ctx = {"project": project}
     return render(request, "opencodelists/project.html", ctx)
+
+
+@method_decorator(login_required, name="dispatch")
+class UserCreate(CreateView):
+    form_class = UserForm
+    model = User
+    template_name = "opencodelists/user_create.html"
+
+    def form_valid(self, form):
+        user = create_user(
+            username=form.cleaned_data["username"],
+            name=form.cleaned_data["name"],
+            email=form.cleaned_data["email"],
+            organisation=form.cleaned_data["organisation"],
+        )
+
+        messages.success(self.request, f"Created user '{user.username}'")
+
+        return redirect("/")

--- a/opencodelists/views.py
+++ b/opencodelists/views.py
@@ -1,11 +1,14 @@
 from django.contrib import messages
+from django.contrib.auth import login
 from django.contrib.auth.decorators import login_required
+from django.core import signing
 from django.shortcuts import get_object_or_404, redirect, render
+from django.template.response import TemplateResponse
 from django.utils.decorators import method_decorator
 from django.views.generic import CreateView
 
-from .actions import create_user
-from .forms import UserForm
+from .actions import activate_user, create_user
+from .forms import UserForm, UserPasswordForm
 from .models import Project, User
 
 
@@ -32,3 +35,42 @@ class UserCreate(CreateView):
         messages.success(self.request, f"Created user '{user.username}'")
 
         return redirect("/")
+
+
+def user_set_password(request, token):
+    # check the signed token from the URL
+    try:
+        username = User.unsign_username(token)
+    except signing.BadSignature:
+        messages.error(request, "Invalid User confirmation URL")
+        return redirect("/")
+
+    # get the user for which we're setting the password
+    try:
+        user = User.objects.get(username=username)
+    except User.DoesNotExist:
+        messages.error(request, "Unknown User")
+        return redirect("/")
+
+    template_name = "opencodelists/user_set_password.html"
+
+    if request.method == "GET":
+        context = {"form": UserPasswordForm()}
+        return TemplateResponse(request, template_name, context)
+
+    form = UserPasswordForm(request.POST)
+
+    if not form.is_valid():
+        context = {"form": form}
+        return TemplateResponse(request, template_name, context)
+
+    user = activate_user(user=user, password=form.cleaned_data["new_password1"])
+
+    # log the, now activated, user in
+    user.backend = "django.contrib.auth.backends.ModelBackend"
+    login(request, user)
+
+    msg = "You have successfully set your password and activated your account"
+    messages.success(request, msg)
+
+    return redirect("/")

--- a/templates/base.html
+++ b/templates/base.html
@@ -71,6 +71,16 @@
     </nav>
 
     <div class="container">
+
+      {% for message in messages %}
+      <div class="alert {{ message.tags }} alert-dismissible mt-3" role="alert">
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+        {{ message }}
+      </div>
+      {% endfor %}
+
       {% block content %} {% endblock %}
 
       <script

--- a/templates/opencodelists/user_activation_url.html
+++ b/templates/opencodelists/user_activation_url.html
@@ -12,7 +12,9 @@
 
     <p>Send the link below to the new user so they can set their password:</p>
 
-    <pre>{{ url }}</pre>
+    <pre class="mb-5">{{ url }}</pre>
+
+    <a class="btn btn-primary" href="{% url 'user-create' %}">Add another User</a>
 
   </div>
 </div>

--- a/templates/opencodelists/user_activation_url.html
+++ b/templates/opencodelists/user_activation_url.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+
+{% block content %}
+
+<div class="row mt-5">
+  <div class="col-8 offset-1">
+
+    <div class="d-flex align-items-baseline">
+      <h2 class="mb-5 mr-3">{{ user.name }}</h2>
+      <small><i>{{ user.email }}</i></small>
+    </div>
+
+    <p>Send the link below to the new user so they can set their password:</p>
+
+    <pre>{{ url }}</pre>
+
+  </div>
+</div>
+<br />
+
+{% endblock %}

--- a/templates/opencodelists/user_create.html
+++ b/templates/opencodelists/user_create.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+
+{% load crispy_forms_tags %}
+
+{% block title_extra %}: New User{% endblock %}
+
+{% block content %}
+<br />
+<h3>New User</h3>
+
+{% crispy form %}
+
+{% endblock %}

--- a/templates/opencodelists/user_set_password.html
+++ b/templates/opencodelists/user_set_password.html
@@ -1,0 +1,83 @@
+{% extends 'base.html' %}
+
+{% block title_extra %}: Set your Password{% endblock %}
+
+{% block content %}
+
+<div class="row mt-5">
+  <div class="col">
+
+    <h3 class="mb-5">Set your Password</h3>
+
+    {% if form.non_field_errors %}
+    <div class="non-field-errors">
+      {% for error in form.non_field_errors %}
+      <p class="text-danger">{{ error }}</p>
+      {% endfor %}
+    </div>
+    {% endif %}
+
+    <form method="POST">
+      {% csrf_token %}
+
+      <div class="form-group row">
+
+        <label for="id_new_password1" class="col-sm-2 col-form-label">New password</label>
+
+        <div class="col-sm-10">
+          <input
+            type="password"
+            name="new_password1"
+            class="form-control{% if form.new_password1.errors %} border-danger{% endif %}"
+            id="id_new_password1"
+            aria-describedby="hint_id_new_password1" />
+
+          <small id="hint_id_new_password1" class="form-text text-muted">
+            {{ form.new_password1.help_text|safe }}
+          </small>
+
+          {% if form.new_password1.errors %}
+          <ul class="list-unstyled my-2">
+            {% for error in form.new_password1.errors %}
+            <li class="text-danger">{{ error }}</li>
+            {% endfor %}
+          </ul>
+          {% endif %}
+        </div>
+
+      </div>
+
+      <div class="form-group row">
+
+        <label for="id_new_password2" class="col-sm-2 col-form-label">Confirm password</label>
+
+        <div class="col-sm-10">
+          <input
+            type="password"
+            name="new_password2"
+            class="form-control{% if form.new_password2.errors %} border-danger{% endif %}"
+            id="id_new_password2" />
+
+          {% if form.new_password2.errors %}
+          <ul class="list-unstyled my-2">
+            {% for error in form.new_password2.errors %}
+            <li class="text-danger">{{ error }}</li>
+            {% endfor %}
+          </ul>
+          {% endif %}
+        </div>
+
+      </div>
+
+      <div class="form-group row">
+        <div class="col-sm-10">
+          <button type="submit" class="btn btn-primary">Save</button>
+        </div>
+      </div>
+
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
This adds pages to allow the creation of a User without using the Django admin.

Flow TLDR:
1. Admin User creates new User
1. Admin User is shown an Activation URL
1. New User visits Activation URL
1. New User sets password, is logged in

---

There are 3 pages to this flow:
* User creation form
* User Activation URL page
* Set password form

### User Creation Form
![](https://p198.p4.n0.cdn.getcloudapp.com/items/04uqd5ZP/Image%202020-09-03%20at%2010.32.49%20am.png?v=5aac6a8774a762ef4eedfb343c7e2177)

This mirrors the admin form but drops a few fields we don't need (eg date joined).  It doesn't add a password so the new User set it at the end of the flow.  New Users are added as in-active so they're unable to login until they set a password.

### User Activation URL Page
![](https://p198.p4.n0.cdn.getcloudapp.com/items/WnuJpkO7/Image%202020-09-03%20at%2010.37.49%20am.png?v=a8a687881fd35257c79387d462a1ae76)

This displays some basic User details (name & email) and their activation URL with the expectation that the a Admin who created the User will pass this link on to the New User.  This page is accessible as long as the User has `is_active = False` set.  This aims to help with lost activation links, but avoids abuse after the User has set a password.

### Set Password Form
![](https://p198.p4.n0.cdn.getcloudapp.com/items/v1u2njd2/Image%202020-09-03%20at%2010.40.40%20am.png?v=5c940c5353a0090cf0e92f2dc148fb9f)

This page lets a User set their password and flips their `is_active` bit to True.  The view checks both the URL is valid (using the signed username string) and the Username is for a valid User.  On a successful submission the User is logged in and redirected to the homepage ready to use the site.

The form driving this page mirrors Django's own `contrib.auth.forms.SetPasswordForm` but without the dependency on a User object.

Note: programmatically logging a User in with Django requires setting a backend on the User which has been hard-coded here since we're using the default backend.

---

### Some Notes on Testing
I've opted for `RequestFactory` where I think they make sense, which is vaguely defined as "produces less test set up".  However, you'll see quite a few uses of `Client`.  This is because Django's messages framework requires a Session (configured via middleware) and while one can set that up with a `RequestFactory` I didn't feel it added anything to the relevant tests.

Fixes #90 