### PR TITLE
Suggest Modules when Unknown One Used with Import Data

### DIFF
--- a/opencodelists/management/commands/import_data.py
+++ b/opencodelists/management/commands/import_data.py
@@ -1,6 +1,17 @@
+import glob
+import os
+import sys
 from importlib import import_module
 
 from django.core.management import BaseCommand
+
+
+def iter_possible_modules():
+    paths = glob.glob("**/import_data.py", recursive=True)
+
+    for path in paths:
+        head, _ = os.path.split(path)
+        yield head.replace(os.sep, ".")
 
 
 class Command(BaseCommand):
@@ -9,6 +20,17 @@ class Command(BaseCommand):
         parser.add_argument("release_dir")
 
     def handle(self, dataset, release_dir, **kwargs):
-        mod = import_module(dataset + ".import_data")
+        try:
+            mod = import_module(dataset + ".import_data")
+        except ModuleNotFoundError:
+            print(f"Could not find an 'import_data.py' module at path '{dataset}'")
+            print("Maybe you meant one of these module paths?")
+
+            possibilities = list(iter_possible_modules())
+            for possibility in possibilities:
+                print(possibility)
+
+            sys.exit(1)
+
         fn = getattr(mod, "import_data")
         fn(release_dir)


### PR DESCRIPTION
This prints out the possible modules for use with the `import_data` command when it fails to import a given module.