### PR TITLE
Fix convert_codelist

### DIFF
--- a/codelists/management/commands/convert_codelist.py
+++ b/codelists/management/commands/convert_codelist.py
@@ -21,10 +21,12 @@ def convert_codelist(project, slug):
     codelist = Codelist.objects.get(project_id=project, slug=slug)
     assert codelist.coding_system_id in ["ctv3", "ctv3tpp"]
 
+    version = codelist.versions.first()
+
     buf = StringIO()
     writer = csv.writer(buf)
     writer.writerow(["id", "name", "active", "notes"])
-    for record in ctv3_to_snomedct(codelist.codes):
+    for record in ctv3_to_snomedct(version.codes):
         writer.writerow(
             [
                 record["id"],


### PR DESCRIPTION
This is a grab bag of updates to fix `convert_codelist`.

Codelists started tracking versions with the `CodelistVersion` model since we last generated SNOMED codelists.  This updates how we create a Codelist to work with the new model.  It doesn't make use of the `create_codelist` action so we can copy over the `version_str` attribute from the CTV3 Codelist instance.