### PR TITLE
Split up Active and Inactive SNOMED Concepts

### DIFF
--- a/templates/codelists/_definition_rows.html
+++ b/templates/codelists/_definition_rows.html
@@ -1,0 +1,33 @@
+{% load definitions %}
+
+<ul>
+  {% for row in rows %}
+  <li>
+    <a href="{% concept_url codelist.coding_system_id row.code %}" style="color: blue">
+      {{ row.name }}
+    </a>
+    (<code>{{ row.code }}</code>)
+
+    {% if row.all_descendants %}
+    and all descendants {% if row.excluded_children %} except:{% endif %}
+    {% endif %}
+
+    {% if row.excluded_children %}
+    <ul class="mb-0">
+
+      {% for child in row.excluded_children %}
+      <li>
+        <a href="{% concept_url codelist.coding_system_id child.code %}" style="color: black">
+          {{ child.name }}
+        </a>
+        (<code>{{ child.code }}</code>)
+      </li>
+      {% endfor %}
+
+    </ul>
+
+    {% endif %}
+  </li>
+
+  {% endfor %}
+</ul>

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -1,6 +1,5 @@
 {% extends 'base.html' %}
 
-{% load definitions %}
 {% load markdown_filter %}
 
 {% block title_extra %}: {{ codelist.name }}{% endblock %}
@@ -213,42 +212,24 @@
         aria-labelledby="definition-tab"
       >
 
-      <p>
-        This definition has been computed by taking the manually created
-        <a href="#full-list">full codelist</a> and converting it to a list of
-        rules that define the codelist.
-      </p>
-      <ul>
-        {% for row in definition_rows %}
-        <li>
-          <a href="{% concept_url codelist.coding_system_id row.code %}" style="color: blue">
-            {{ row.name }}
-          </a>
-          (<code>{{ row.code }}</code>)
+        <p>
+          This definition has been computed by taking the manually created
+          <a href="#full-list">full codelist</a> and converting it to a list of
+          rules that define the codelist.
+        </p>
 
-          {% if row.all_descendants %}
-          and all descendants {% if row.excluded_children %} except:{% endif %}
-          {% endif %}
+        {% if definition_rows.active %}
+        <strong>Active Concepts</strong>
+        {% include "codelists/_definition_rows.html" with rows=definition_rows.active %}
 
-          {% if row.excluded_children %}
-          <ul class="mb-0">
+        <hr />
+        {% endif %}
 
-            {% for child in row.excluded_children %}
-            <li>
-              <a href="{% concept_url codelist.coding_system_id child.code %}" style="color: black">
-                {{ child.name }}
-              </a>
-              (<code>{{ child.code }}</code>)
-            </li>
-            {% endfor %}
+        {% if definition_rows.inactive %}
+        <strong>Inactive Concepts</strong>
+        {% include "codelists/_definition_rows.html" with rows=definition_rows.inactive %}
+        {% endif %}
 
-          </ul>
-
-          {% endif %}
-        </li>
-
-        {% endfor %}
-      </ul>
       </div>
       {% endif %}
 

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -218,6 +218,7 @@
           rules that define the codelist.
         </p>
 
+        {% if codelist.coding_system_id == "snomedct" %}
         {% if definition_rows.active %}
         <strong>Active Concepts</strong>
         {% include "codelists/_definition_rows.html" with rows=definition_rows.active %}
@@ -228,6 +229,10 @@
         {% if definition_rows.inactive %}
         <strong>Inactive Concepts</strong>
         {% include "codelists/_definition_rows.html" with rows=definition_rows.inactive %}
+        {% endif %}
+
+        {% else %}
+        {% include "codelists/_definition_rows.html" with rows=definition_rows.active %}
         {% endif %}
 
       </div>


### PR DESCRIPTION
This splits up the inactive and active SNOMED Concepts in the Definition tab of a Codelist:

![](https://p198.p4.n0.cdn.getcloudapp.com/items/yAubzJem/Image%202020-09-07%20at%209.55.42%20am.png?v=397c42035d992b933c27d3427ed7c28b)

For non-SNOMED definitions it keeps the Definition unchanged:

![](https://p198.p4.n0.cdn.getcloudapp.com/items/Qwu0o8yj/Image%202020-09-07%20at%209.56.30%20am.png?v=935b6321b0213d3bf6469ee69a5fb5f7)

Fixes #164 