### PR TITLE
Quieter Deploys

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -29,7 +29,7 @@ def create_venv():
 
 
 def update_from_git():
-    run("git fetch --all")
+    run("git fetch --all --quiet")
     run("git checkout --force origin/master")
 
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -48,7 +48,7 @@ def run_migrations():
 
 
 def install_js_requirements():
-    run("npm install")
+    run("npm install --no-progress")
 
 
 def build_static_assets():


### PR DESCRIPTION
This sets both`git-fetch` and `npm install` to quiet mode so deploys don't output progress line-by-line.