### PR TITLE
Revert "Tell Fabric to explicitly use the user's ssh config"

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -8,7 +8,6 @@ env.colorize_errors = True
 env.hosts = ["smallweb1.ebmdatalab.net"]
 env.user = "root"
 env.path = "/var/www/opencodelists"
-env.use_ssh_config = True
 
 
 def initalise_directory():


### PR DESCRIPTION
This reverts commit d83b469cc24861149b4884343ca775f564b5d3c7.

Disable fabric's use_ssh_config option so automated deploys by EBMBot can work.  With this set to true EBMBot deploys require a password on the server.

This was added to enable deploys from macOS by @ghickman, however we later discovered the issue was macOS not adding SSH keys to the agent by default.