### PR TITLE
Fix rendering of long rows

### DIFF
--- a/static/src/js/builder.jsx
+++ b/static/src/js/builder.jsx
@@ -255,7 +255,7 @@ function Row(props) {
 
   const visibility = isVisible ? "d-flex" : "d-none";
   const rowSpacing = row.pipes.length === 0 ? "mt-2" : "mt-0";
-  const className = `row ${rowSpacing} ${visibility}`;
+  const className = `${rowSpacing} ${visibility}`;
 
   return (
     <div className={className}>


### PR DESCRIPTION
This was broken in f106ba39.  Original code only worked because the
first `class="row"` is overridden by the second `class="{className}"`.

Before: 

![image](https://user-images.githubusercontent.com/28734/92617809-9c185a00-f2b7-11ea-99e7-587eb12a4f67.png)

After:

![image](https://user-images.githubusercontent.com/28734/92617986-ca963500-f2b7-11ea-9e87-1293307e8cdd.png)
