### PR TITLE
Extract TermAndCode component into a separate file

### DIFF
--- a/static/src/js/TermAndCode.jsx
+++ b/static/src/js/TermAndCode.jsx
@@ -1,0 +1,50 @@
+import React from "react";
+
+export default function TermAndCode(props) {
+  const {
+    term,
+    code,
+    pipes,
+    status,
+    hasDescendants,
+    isExpanded,
+    toggleVisibility,
+  } = props;
+
+  const termStyle = {
+    color: {
+      "!": "red",
+      "-": "gray",
+      "(-)": "gray",
+    }[status],
+  };
+
+  return (
+    <div style={{ paddingLeft: "10px", whiteSpace: "nowrap" }}>
+      {pipes.map((pipe, ix) => (
+        <span
+          key={ix}
+          style={{
+            display: "inline-block",
+            textAlign: "center",
+            width: "20px",
+          }}
+        >
+          {pipe}
+        </span>
+      ))}
+      {hasDescendants ? (
+        <span
+          onClick={toggleVisibility.bind(null, code)}
+          style={{ cursor: "pointer" }}
+        >
+          {isExpanded ? "⊟" : "⊞"}
+        </span>
+      ) : null}
+      <span style={termStyle}>{term}</span>{" "}
+      <span>
+        (<code>{code}</code>)
+      </span>
+    </div>
+  );
+}

--- a/static/src/js/builder/codelistbuilder.jsx
+++ b/static/src/js/builder/codelistbuilder.jsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 
+import TermAndCode from "../TermAndCode";
 import { getCookie } from "../utils";
 
 class CodelistBuilder extends React.Component {
@@ -318,55 +319,6 @@ function Button(props) {
     >
       {symbol}
     </button>
-  );
-}
-
-function TermAndCode(props) {
-  const {
-    term,
-    code,
-    pipes,
-    status,
-    hasDescendants,
-    isExpanded,
-    toggleVisibility,
-  } = props;
-
-  const termStyle = {
-    color: {
-      "!": "red",
-      "-": "gray",
-      "(-)": "gray",
-    }[status],
-  };
-
-  return (
-    <div style={{ paddingLeft: "10px", whiteSpace: "nowrap" }}>
-      {pipes.map((pipe, ix) => (
-        <span
-          key={ix}
-          style={{
-            display: "inline-block",
-            textAlign: "center",
-            width: "20px",
-          }}
-        >
-          {pipe}
-        </span>
-      ))}
-      {hasDescendants ? (
-        <span
-          onClick={toggleVisibility.bind(null, code)}
-          style={{ cursor: "pointer" }}
-        >
-          {isExpanded ? "⊟" : "⊞"}
-        </span>
-      ) : null}
-      <span style={termStyle}>{term}</span>{" "}
-      <span>
-        (<code>{code}</code>)
-      </span>
-    </div>
   );
 }
 


### PR DESCRIPTION
This pulls the TermAndCode component into a separate file ready to use it to build the Tree tab on the Codelist page.