### PR TITLE
Tree Tab 2.0

### DIFF
--- a/builder/views.py
+++ b/builder/views.py
@@ -76,11 +76,11 @@ def codelist(request, username, codelist_slug, search_slug=None):
 
     hierarchy = Hierarchy.from_codes(coding_system, all_codes)
 
-    code_to_term = coding_system.code_to_term(all_codes, hierarchy)
-    code_to_type = coding_system.code_to_type(all_codes, hierarchy)
-
     ancestor_codes = hierarchy.filter_to_ultimate_ancestors(set(displayed_codes))
-    tables = tree_tables(ancestor_codes, hierarchy, code_to_term, code_to_type)
+    codes_by_type = coding_system.codes_by_type(ancestor_codes, hierarchy)
+    code_to_term = coding_system.code_to_term(all_codes, hierarchy)
+
+    tables = tree_tables(codes_by_type, hierarchy, code_to_term)
 
     searches = [
         {"term": s.term, "url": s.get_absolute_url(), "active": s == search}

--- a/builder/views.py
+++ b/builder/views.py
@@ -1,5 +1,4 @@
 import json
-import re
 
 from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse
@@ -75,14 +74,10 @@ def codelist(request, username, codelist_slug, search_slug=None):
         displayed_codes = [c for c in displayed_codes if code_to_status[c] == "!"]
         filter = "in conflict"
 
-    code_to_term_and_type = {
-        code: re.match(r"(^.*) \(([\w/ ]+)\)$", term).groups()
-        for code, term in coding_system.lookup_names(all_codes).items()
-    }
-    code_to_term = {code: term for code, (term, _) in code_to_term_and_type.items()}
-    code_to_type = {code: type for code, (_, type) in code_to_term_and_type.items()}
-
     hierarchy = Hierarchy.from_codes(coding_system, all_codes)
+
+    code_to_term = coding_system.code_to_term(all_codes, hierarchy)
+    code_to_type = coding_system.code_to_type(all_codes, hierarchy)
 
     ancestor_codes = hierarchy.filter_to_ultimate_ancestors(set(displayed_codes))
     tables = tree_tables(ancestor_codes, hierarchy, code_to_term, code_to_type)

--- a/codelists/presenters.py
+++ b/codelists/presenters.py
@@ -1,7 +1,6 @@
 from itertools import groupby
 
 import attr
-from django.urls import reverse
 
 
 @attr.s
@@ -70,49 +69,6 @@ def build_definition_rows(coding_system, hierarchy, definition):
     excluded_rules = sorted(definition.excluding_rules(), key=name_for_rule)
 
     return list(_iter_rules(hierarchy, included_rules, name_for_rule, excluded_rules))
-
-
-def build_html_tree_highlighting_codes(coding_system, hierarchy, definition):
-    codes = definition.codes(hierarchy)
-    codes_in_definition = {r.code for r in definition.including_rules()}
-    codes_in_hierarchy = hierarchy.nodes
-    code_to_name = coding_system.lookup_names(codes_in_hierarchy)
-    sort_key = code_to_name.__getitem__
-
-    lines = []
-    last_direction = 1
-    for node in hierarchy.walk_depth_first_as_tree(sort_key=sort_key):
-        direction = node.direction
-        code = node.label
-
-        if direction == last_direction == 1:
-            lines.append("<ul>")
-        elif direction == last_direction == -1:
-            lines.append("</ul>")
-
-        last_direction = direction
-
-        if direction == -1:
-            continue
-
-        if code in codes:
-            colour = "blue"
-        else:
-            colour = "black"
-
-        style = f"color: {colour}"
-
-        if code in codes_in_definition:
-            style += "; text-decoration: underline"
-
-        name = code_to_name[code]
-        url = reverse(f"{coding_system.id}:concept", args=[code])
-
-        lines.append(
-            f'<li><a href="{url}" style="{style}">{name}</a> (<code>{code}</code>)</li>'
-        )
-
-    return "\n".join(lines)
 
 
 def tree_tables(ancestor_codes, hierarchy, code_to_term, code_to_type):

--- a/codelists/presenters.py
+++ b/codelists/presenters.py
@@ -1,5 +1,3 @@
-from itertools import groupby
-
 import attr
 
 
@@ -71,25 +69,18 @@ def build_definition_rows(coding_system, hierarchy, definition):
     return list(_iter_rules(hierarchy, included_rules, name_for_rule, excluded_rules))
 
 
-def tree_tables(ancestor_codes, hierarchy, code_to_term, code_to_type):
-    """Return list of tables of codes arranged in trees, grouped by type of code.
+def tree_tables(codes_by_type, hierarchy, code_to_term):
+    """
+    Return list of tables of codes arranged in trees, grouped by type of code.
 
     Each table is a dict, with a heading and a list of rows.
     """
 
-    sort_by_type_key = code_to_type.__getitem__
     sort_by_term_key = code_to_term.__getitem__
-
-    type_to_codes = {
-        type: list(codes_for_type)
-        for type, codes_for_type in groupby(
-            sorted(ancestor_codes, key=sort_by_type_key), sort_by_type_key
-        )
-    }
 
     tables = []
 
-    for type, codes_for_type in sorted(type_to_codes.items()):
+    for type, codes_for_type in sorted(codes_by_type.items()):
         rows = []
 
         for ancestor_code in sorted(codes_for_type, key=sort_by_term_key):

--- a/codelists/tests/test_presenters.py
+++ b/codelists/tests/test_presenters.py
@@ -71,29 +71,6 @@ def test_build_definition_rows():
     assert excluded["code"] == "8"
 
 
-def test_build_html_tree_highlighting_codes():
-    fixtures_path = Path(settings.BASE_DIR, "coding_systems", "snomedct", "fixtures")
-    call_command("loaddata", fixtures_path / "core-model-components.json")
-    call_command("loaddata", fixtures_path / "tennis-elbow.json")
-
-    with open(fixtures_path / "disorder-of-elbow-excl-arthritis.csv") as f:
-        cl = CodelistFactory(csv_data=f.read())
-
-    coding_system = cl.coding_system
-    clv = cl.versions.get()
-    hierarchy = Hierarchy.from_codes(coding_system, clv.codes)
-    definition = Definition.from_codes(set(clv.codes), hierarchy)
-
-    html = presenters.build_html_tree_highlighting_codes(
-        coding_system, hierarchy, definition
-    )
-
-    with open(
-        Path(settings.BASE_DIR, "codelists", "tests", "expected_html_tree.html")
-    ) as f:
-        assert html.strip() == f.read().strip()
-
-
 def test_tree_tables():
     fixtures_path = Path(settings.BASE_DIR, "coding_systems", "snomedct", "fixtures")
     call_command("loaddata", fixtures_path / "core-model-components.json")

--- a/codelists/tests/test_presenters.py
+++ b/codelists/tests/test_presenters.py
@@ -98,7 +98,6 @@ def test_tree_tables():
     assert presenters.tree_tables(codes_by_type, hierarchy, code_to_term) == [
         {
             "heading": "Disorder",
-            # fmt: off
             "rows": [
                 {
                     "code": "128133004",
@@ -141,6 +140,5 @@ def test_tree_tables():
                     "pipes": ["└"],
                 },
             ],
-            # fmt: on
         }
     ]

--- a/codelists/views.py
+++ b/codelists/views.py
@@ -311,7 +311,7 @@ def version(request, project_slug, codelist_slug, qualified_version_str):
         trees = tree_tables(codes_by_type, hierarchy, code_to_term)
 
         r = functools.partial(reverse, f"{coding_system.id}:concept")
-        code_to_url = {code: r(args=[code]) for code in clv.codes}
+        code_to_url = {code: r(args=[code]) for code in hierarchy.nodes}
 
         definition = Definition.from_codes(set(clv.codes), hierarchy)
         rows = build_definition_rows(coding_system, hierarchy, definition)

--- a/codelists/views.py
+++ b/codelists/views.py
@@ -303,14 +303,9 @@ def version(request, project_slug, codelist_slug, qualified_version_str):
         child_map = {c: list(pp) for c, pp in hierarchy.child_map.items()}
 
         ancestor_codes = hierarchy.filter_to_ultimate_ancestors(set(clv.codes))
-        code_to_type = dict(coding_system.code_to_type(clv.codes, hierarchy))
+        codes_by_type = coding_system.codes_by_type(ancestor_codes, hierarchy)
         code_to_term = coding_system.code_to_term(clv.codes, hierarchy)
-        trees = tree_tables(
-            ancestor_codes,
-            hierarchy,
-            code_to_term,
-            code_to_type,
-        )
+        trees = tree_tables(codes_by_type, hierarchy, code_to_term)
 
         definition = Definition.from_codes(set(clv.codes), hierarchy)
         rows = build_definition_rows(coding_system, hierarchy, definition)

--- a/coding_systems/snomedct/coding_system.py
+++ b/coding_systems/snomedct/coding_system.py
@@ -1,3 +1,4 @@
+import collections
 import re
 
 from opencodelists.db_utils import query
@@ -109,5 +110,17 @@ def code_to_term(codes, hierarchy):
     return {code: term for code, (term, _) in code_to_term_and_type(codes).items()}
 
 
-def code_to_type(codes, hierarchy):
-    return {code: type for code, (_, type) in code_to_term_and_type(codes).items()}
+def codes_by_type(codes, hierarchy):
+    """Group codes by their Type"""
+    # create a lookup of code -> type
+    code_to_type = {
+        code: type for code, (_, type) in code_to_term_and_type(codes).items()
+    }
+
+    lookup = collections.defaultdict(list)
+
+    for code in codes:
+        type = code_to_type[code]
+        lookup[type].append(code)
+
+    return dict(lookup)

--- a/coding_systems/snomedct/coding_system.py
+++ b/coding_systems/snomedct/coding_system.py
@@ -1,3 +1,5 @@
+import re
+
 from opencodelists.db_utils import query
 
 from .models import FULLY_SPECIFIED_NAME, IS_A, Concept, Description
@@ -6,6 +8,9 @@ name = "SNOMED CT"
 short_name = "SNOMED CT"
 
 root = "138875005"
+
+
+term_and_type_pat = re.compile(r"(^.*) \(([\w/ ]+)\)$")
 
 
 def lookup_names(codes):
@@ -85,3 +90,24 @@ def descendant_relationships(codes):
     """
 
     return query(sql, codes)
+
+
+def _iter_code_to_term_and_type(codes: set):
+    for code, term in lookup_names(codes).items():
+        match = term_and_type_pat.match(term)
+        term_and_type = match.groups() if match else (term, "unknown")
+
+        yield code, term_and_type
+
+
+def code_to_term_and_type(codes):
+    codes = set(codes)
+    return dict(_iter_code_to_term_and_type(codes))
+
+
+def code_to_term(codes, hierarchy):
+    return {code: term for code, (term, _) in code_to_term_and_type(codes).items()}
+
+
+def code_to_type(codes, hierarchy):
+    return {code: type for code, (_, type) in code_to_term_and_type(codes).items()}

--- a/static/src/js/Code.jsx
+++ b/static/src/js/Code.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+const Code = (props) => (
+  <span>
+    (<code>{props.code}</code>)
+  </span>
+);
+
+export default Code;

--- a/static/src/js/Code.jsx
+++ b/static/src/js/Code.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 const Code = (props) => (
-  <span>
+  <span className="ml-1">
     (<code>{props.code}</code>)
   </span>
 );

--- a/static/src/js/DescendantToggle.jsx
+++ b/static/src/js/DescendantToggle.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+const DescendantToggle = (props) => (
+  <span
+    onClick={props.toggleVisibility.bind(null, props.code)}
+    style={{ cursor: "pointer", margin: "0 4px" }}
+  >
+    {props.isExpanded ? "⊟" : "⊞"}
+  </span>
+);
+
+export default DescendantToggle;

--- a/static/src/js/DescendantToggle.jsx
+++ b/static/src/js/DescendantToggle.jsx
@@ -3,7 +3,7 @@ import React from "react";
 const DescendantToggle = (props) => (
   <span
     onClick={props.toggleVisibility.bind(null, props.code)}
-    style={{ cursor: "pointer", margin: "0 4px" }}
+    style={{ cursor: "pointer", marginLeft: "2px", marginRight: "4px" }}
   >
     {props.isExpanded ? "⊟" : "⊞"}
   </span>

--- a/static/src/js/Pipes.jsx
+++ b/static/src/js/Pipes.jsx
@@ -7,6 +7,8 @@ const Pipes = (props) =>
       style={{
         display: "inline-block",
         textAlign: "center",
+        paddingLeft: "3px",
+        paddingRight: "6px",
         width: "20px",
       }}
     >

--- a/static/src/js/Pipes.jsx
+++ b/static/src/js/Pipes.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+const Pipes = (props) =>
+  props.pipes.map((pipe, ix) => (
+    <span
+      key={ix}
+      style={{
+        display: "inline-block",
+        textAlign: "center",
+        width: "20px",
+      }}
+    >
+      {pipe}
+    </span>
+  ));
+
+export default Pipes;

--- a/static/src/js/Term.jsx
+++ b/static/src/js/Term.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+const statusToColour = {
+  "!": "red",
+  "-": "gray",
+  "(-)": "gray",
+};
+
+const Term = (props) => {
+  const style = { color: statusToColour[props.status] };
+
+  return <span style={style}>{props.term}</span>;
+};
+
+export default Term;

--- a/static/src/js/TermAndCode.jsx
+++ b/static/src/js/TermAndCode.jsx
@@ -36,7 +36,7 @@ export default function TermAndCode(props) {
       {hasDescendants ? (
         <span
           onClick={toggleVisibility.bind(null, code)}
-          style={{ cursor: "pointer" }}
+          style={{ cursor: "pointer", margin: "0 4px" }}
         >
           {isExpanded ? "⊟" : "⊞"}
         </span>

--- a/static/src/js/TermAndCode.jsx
+++ b/static/src/js/TermAndCode.jsx
@@ -1,50 +1,26 @@
 import React from "react";
 
+import Code from "./Code";
+import DescendantToggle from "./DescendantToggle";
+import Pipes from "./Pipes";
+import Term from "./Term";
+
 export default function TermAndCode(props) {
-  const {
-    term,
-    code,
-    pipes,
-    status,
-    hasDescendants,
-    isExpanded,
-    toggleVisibility,
-  } = props;
-
-  const termStyle = {
-    color: {
-      "!": "red",
-      "-": "gray",
-      "(-)": "gray",
-    }[status],
-  };
-
   return (
     <div style={{ paddingLeft: "10px", whiteSpace: "nowrap" }}>
-      {pipes.map((pipe, ix) => (
-        <span
-          key={ix}
-          style={{
-            display: "inline-block",
-            textAlign: "center",
-            width: "20px",
-          }}
-        >
-          {pipe}
-        </span>
-      ))}
-      {hasDescendants ? (
-        <span
-          onClick={toggleVisibility.bind(null, code)}
-          style={{ cursor: "pointer", margin: "0 4px" }}
-        >
-          {isExpanded ? "⊟" : "⊞"}
-        </span>
+      <Pipes pipes={props.pipes} />
+
+      {props.hasDescendants ? (
+        <DescendantToggle
+          code={props.code}
+          isExpanded={props.isExpanded}
+          toggleVisibility={props.toggleVisibility}
+        />
       ) : null}
-      <span style={termStyle}>{term}</span>{" "}
-      <span>
-        (<code>{code}</code>)
-      </span>
+
+      <Term status={props.status} term={props.term} />
+
+      <Code code={props.code} />
     </div>
   );
 }

--- a/static/src/js/builder/codelistbuilder.jsx
+++ b/static/src/js/builder/codelistbuilder.jsx
@@ -2,7 +2,10 @@
 
 import React from "react";
 
-import TermAndCode from "../TermAndCode";
+import Code from "../Code";
+import DescendantToggle from "../DescendantToggle";
+import Pipes from "../Pipes";
+import Term from "../Term";
 import { getCookie } from "../utils";
 
 class CodelistBuilder extends React.Component {
@@ -295,15 +298,17 @@ function Row(props) {
 
       <MoreInfo status={status} />
 
-      <TermAndCode
-        term={row.term}
-        code={row.code}
-        pipes={row.pipes}
-        status={status}
-        hasDescendants={hasDescendants}
-        isExpanded={isExpanded}
-        toggleVisibility={toggleVisibility}
-      />
+      <div style={{ paddingLeft: "10px", whiteSpace: "nowrap" }}>
+        <Pipes pipes={row.pipes} />
+        {hasDescendants ? (
+          <DescendantToggle
+            code={row.code}
+            isExpanded={isExpanded}
+            toggleVisibility={toggleVisibility}
+          />
+        ) : null}
+        <Term status={status} term={row.term} /> <Code code={row.code} />
+      </div>
     </div>
   );
 }

--- a/static/src/js/builder/codelistbuilder.jsx
+++ b/static/src/js/builder/codelistbuilder.jsx
@@ -307,7 +307,8 @@ function Row(props) {
             toggleVisibility={toggleVisibility}
           />
         ) : null}
-        <Term status={status} term={row.term} /> <Code code={row.code} />
+        <Term status={status} term={row.term} />
+        <Code code={row.code} />
       </div>
     </div>
   );

--- a/static/src/js/tree/Tree.jsx
+++ b/static/src/js/tree/Tree.jsx
@@ -33,7 +33,7 @@ class Tree extends React.Component {
   renderTerm(code, term) {
     const element = <Term term={term} />;
 
-    const inDefinition = this.props.definitionCodes.includes(code);
+    const inDefinition = this.props.codesInDefinition.includes(code);
 
     // conditionally wrap Term in an <href> element if there's a URL for it. We
     // only want to link to codes included in the codelist so some codes will

--- a/static/src/js/tree/Tree.jsx
+++ b/static/src/js/tree/Tree.jsx
@@ -30,6 +30,28 @@ class Tree extends React.Component {
       .every((ancestor) => this.state[ancestor]);
   }
 
+  renderTerm(code, term) {
+    const element = <Term term={term} />;
+
+    const inDefinition = this.props.definitionCodes.includes(code);
+
+    // conditionally wrap Term in an <href> element if there's a URL for it. We
+    // only want to link to codes included in the codelist so some codes will
+    // stay unlinked.
+    if (code in this.props.codeToURL) {
+      return (
+        <a
+          style={inDefinition ? { textDecoration: "underline" } : null}
+          href={this.props.codeToURL[code]}
+        >
+          {element}
+        </a>
+      );
+    } else {
+      return element;
+    }
+  }
+
   render() {
     return (
       <div>
@@ -51,7 +73,7 @@ class Tree extends React.Component {
                     toggleVisibility={this.toggleVisibility}
                   />
                 ) : null}
-                <Term term={row.term} /> <Code code={row.code} />
+                {this.renderTerm(row.code, row.term)} <Code code={row.code} />
               </div>
             ))}
           </div>

--- a/static/src/js/tree/Tree.jsx
+++ b/static/src/js/tree/Tree.jsx
@@ -73,7 +73,8 @@ class Tree extends React.Component {
                     toggleVisibility={this.toggleVisibility}
                   />
                 ) : null}
-                {this.renderTerm(row.code, row.term)} <Code code={row.code} />
+                {this.renderTerm(row.code, row.term)}
+                <Code code={row.code} />
               </div>
             ))}
           </div>

--- a/static/src/js/tree/Tree.jsx
+++ b/static/src/js/tree/Tree.jsx
@@ -31,25 +31,16 @@ class Tree extends React.Component {
   }
 
   renderTerm(code, term) {
-    const element = <Term term={term} />;
-
     const inDefinition = this.props.codesInDefinition.includes(code);
 
-    // conditionally wrap Term in an <href> element if there's a URL for it. We
-    // only want to link to codes included in the codelist so some codes will
-    // stay unlinked.
-    if (code in this.props.codeToURL) {
-      return (
-        <a
-          style={inDefinition ? { textDecoration: "underline" } : null}
-          href={this.props.codeToURL[code]}
-        >
-          {element}
-        </a>
-      );
-    } else {
-      return element;
-    }
+    return (
+      <a
+        style={inDefinition ? { textDecoration: "underline" } : null}
+        href={this.props.codeToURL[code]}
+      >
+        <Term term={term} />;
+      </a>
+    );
   }
 
   render() {

--- a/static/src/js/tree/Tree.jsx
+++ b/static/src/js/tree/Tree.jsx
@@ -1,0 +1,58 @@
+import React from "react";
+import TermAndCode from "../TermAndCode";
+
+class Tree extends React.Component {
+  constructor(props) {
+    super(props);
+
+    // initialise state with {code: true, …} for every code on the page
+    const codes = Array.from(props.hierarchy.nodes);
+    this.state = Object.fromEntries(codes.map((node) => [node, true]));
+
+    this.toggleVisibility = this.toggleVisibility.bind(this);
+  }
+
+  toggleVisibility(code) {
+    this.setState((state) => ({ [code]: !state[code] }));
+  }
+
+  hasDescendants(code) {
+    return this.props.hierarchy.getDescendants(code).length > 0;
+  }
+
+  isVisible(code) {
+    return this.props.hierarchy
+      .getAncestors(code)
+      .every((ancestor) => this.state[ancestor]);
+  }
+
+  render() {
+    return (
+      <div>
+        {this.props.trees.map((tree, i) => (
+          <div className="mb-4" key={i}>
+            <h4>{tree.heading}</h4>
+
+            {tree.rows.map((row, i) => (
+              <div
+                className={this.isVisible(row.code) ? "d-flex" : "d-none"}
+                key={i}
+              >
+                <TermAndCode
+                  term={row.term}
+                  code={row.code}
+                  pipes={row.pipes}
+                  hasDescendants={this.hasDescendants(row.code)}
+                  isExpanded={this.state[row.code]}
+                  toggleVisibility={this.toggleVisibility}
+                />
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    );
+  }
+}
+
+export default Tree;

--- a/static/src/js/tree/Tree.jsx
+++ b/static/src/js/tree/Tree.jsx
@@ -32,12 +32,19 @@ class Tree extends React.Component {
 
   renderTerm(code, term) {
     const inDefinition = this.props.codesInDefinition.includes(code);
+    const inList = this.props.codesInList.includes(code);
+
+    let style;
+    if (inDefinition) {
+      style = { color: "blue" };
+    } else if (inList) {
+      style = { color: "blue", textDecoration: "underline" };
+    } else {
+      style = { color: "black" };
+    }
 
     return (
-      <a
-        style={inDefinition ? { textDecoration: "underline" } : null}
-        href={this.props.codeToURL[code]}
-      >
+      <a style={style} href={this.props.codeToURL[code]}>
         <Term term={term} />;
       </a>
     );

--- a/static/src/js/tree/Tree.jsx
+++ b/static/src/js/tree/Tree.jsx
@@ -1,5 +1,9 @@
 import React from "react";
-import TermAndCode from "../TermAndCode";
+
+import Code from "../Code";
+import DescendantToggle from "../DescendantToggle";
+import Pipes from "../Pipes";
+import Term from "../Term";
 
 class Tree extends React.Component {
   constructor(props) {
@@ -37,15 +41,17 @@ class Tree extends React.Component {
               <div
                 className={this.isVisible(row.code) ? "d-flex" : "d-none"}
                 key={i}
+                style={{ whiteSpace: "nowrap" }}
               >
-                <TermAndCode
-                  term={row.term}
-                  code={row.code}
-                  pipes={row.pipes}
-                  hasDescendants={this.hasDescendants(row.code)}
-                  isExpanded={this.state[row.code]}
-                  toggleVisibility={this.toggleVisibility}
-                />
+                <Pipes pipes={row.pipes} />
+                {this.hasDescendants(row.code) ? (
+                  <DescendantToggle
+                    code={row.code}
+                    isExpanded={this.state[row.code]}
+                    toggleVisibility={this.toggleVisibility}
+                  />
+                ) : null}
+                <Term term={row.term} /> <Code code={row.code} />
               </div>
             ))}
           </div>

--- a/static/src/js/tree/index.jsx
+++ b/static/src/js/tree/index.jsx
@@ -15,6 +15,11 @@ const hierarchy = new Hierarchy(
 );
 
 ReactDOM.render(
-  <Tree hierarchy={hierarchy} trees={readValueFromPage("trees")} />,
+  <Tree
+    codeToURL={readValueFromPage("codeToURL")}
+    definitionCodes={readValueFromPage("definitionCodes")}
+    hierarchy={hierarchy}
+    trees={readValueFromPage("trees")}
+  />,
   document.querySelector("#codelist-tree")
 );

--- a/static/src/js/tree/index.jsx
+++ b/static/src/js/tree/index.jsx
@@ -1,0 +1,20 @@
+"use strict";
+
+import ReactDOM from "react-dom";
+// Although React is not used in this module, if this line is removed, there is
+// a runtime error in codelistbuilder.jsx.
+import React from "react";
+
+import Hierarchy from "../hierarchy";
+import Tree from "./Tree";
+import { readValueFromPage } from "../utils";
+
+const hierarchy = new Hierarchy(
+  readValueFromPage("parent-map"),
+  readValueFromPage("child-map")
+);
+
+ReactDOM.render(
+  <Tree hierarchy={hierarchy} trees={readValueFromPage("trees")} />,
+  document.querySelector("#codelist-tree")
+);

--- a/static/src/js/tree/index.jsx
+++ b/static/src/js/tree/index.jsx
@@ -17,7 +17,7 @@ const hierarchy = new Hierarchy(
 ReactDOM.render(
   <Tree
     codeToURL={readValueFromPage("codeToURL")}
-    definitionCodes={readValueFromPage("definitionCodes")}
+    codesInDefinition={readValueFromPage("codesInDefinition")}
     hierarchy={hierarchy}
     trees={readValueFromPage("trees")}
   />,

--- a/static/src/js/tree/index.jsx
+++ b/static/src/js/tree/index.jsx
@@ -18,6 +18,7 @@ ReactDOM.render(
   <Tree
     codeToURL={readValueFromPage("codeToURL")}
     codesInDefinition={readValueFromPage("codesInDefinition")}
+    codesInList={readValueFromPage("codesInList")}
     hierarchy={hierarchy}
     trees={readValueFromPage("trees")}
   />,

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -344,6 +344,8 @@
 </script>
 
 {{ child_map|json_script:"child-map" }}
+{{ code_to_url|json_script:"codeToURL" }}
+{{ codes_in_definition|json_script:"definitionCodes" }}
 {{ parent_map|json_script:"parent-map" }}
 {{ trees|json_script:"trees" }}
 

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -345,7 +345,7 @@
 
 {{ child_map|json_script:"child-map" }}
 {{ code_to_url|json_script:"codeToURL" }}
-{{ codes_in_definition|json_script:"definitionCodes" }}
+{{ codes_in_definition|json_script:"codesInDefinition" }}
 {{ parent_map|json_script:"parent-map" }}
 {{ trees|json_script:"trees" }}
 

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 
 {% load markdown_filter %}
+{% load static %}
 
 {% block title_extra %}: {{ codelist.name }}{% endblock %}
 
@@ -150,7 +151,7 @@
           >Full list</a
         >
       </li>
-      {% if html_tree %}
+      {% if trees %}
       <li class="nav-item">
         <a
           class="nav-link"
@@ -262,7 +263,7 @@
         </table>
       </div>
 
-      {% if html_tree %}
+      {% if trees %}
       <div
         class="tab-pane fade p-4"
         id="tree"
@@ -275,7 +276,7 @@
         Codes in the <a href="#full-list">full codelist</a> are in blue.
         Related codes not in the codelist are in black.
       </p>
-      {{ html_tree|safe }}
+        <div id="codelist-tree"></div>
       </div>
       {% endif %}
     </div>
@@ -341,4 +342,10 @@
     $('#tab-list a[href="' + hash + '"]').tab("show");
   }
 </script>
+
+{{ child_map|json_script:"child-map" }}
+{{ parent_map|json_script:"parent-map" }}
+{{ trees|json_script:"trees" }}
+
+<script src="{% static 'js/tree.bundle.js' %}"></script>
 {% endblock %}

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -346,6 +346,7 @@
 {{ child_map|json_script:"child-map" }}
 {{ code_to_url|json_script:"codeToURL" }}
 {{ codes_in_definition|json_script:"codesInDefinition" }}
+{{ clv.codes|json_script:"codesInList" }}
 {{ parent_map|json_script:"parent-map" }}
 {{ trees|json_script:"trees" }}
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: {
     builder: "./static/src/js/builder/index.jsx",
     codelist: "./static/src/js/codelist.js",
+    tree: "./static/src/js/tree/index.jsx",
   },
   output: {
     path: path.resolve(__dirname, "static", "dist", "js"),


### PR DESCRIPTION
This rebuilds the Codelist version page's Tree tab with a modified version of the CodelistBuilder component.  It turned out that only `TermAndCode` was needed from CodelistBuilder so I've left the rest of the sub components where they are.

This also pulls a couple of `tree_tables`-related structures into the coding system specific modules (so we can support CTV3 and SNOMED).  Most notbably, concept codes grouped by type are now generated in the coding system (since CTV3 codes can have more than one group) and passed into `tree_tables`.

These changes brought up the single code Hierarchy edge case (#193), which in turn brought up the three view tests (checking redirects work as expected) that broke due to this work.  I've reduced their scope to only check they are redirecting to the correct location so they're less brittle in the future.

**Aplastic Anaemia (SNOMED)**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/Qwu0mrQQ/Image%202020-09-16%20at%203.21.06%20pm.png?v=859f753c81dbb03eb3a1295a0a079529)

**Aplastic Anaemia**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/o0u8w0ge/Image%202020-09-16%20at%203.22.23%20pm.png?v=d592f7dee6a9492b034c8ec072cd1966)

Fixes #100 
Fixes #165 