### PR TITLE
Deploy as ebmbot

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -6,7 +6,7 @@ env.forward_agent = True
 env.colorize_errors = True
 
 env.hosts = ["smallweb1.ebmdatalab.net"]
-env.user = "root"
+env.user = "ebmbot"
 env.path = "/var/www/opencodelists"
 
 


### PR DESCRIPTION
This copies the configuration of OpenPrescribing to configure password-less sudo for members of the `fabric` group so we can deploy from ebmbot as the user `ebmbot` (mirror OP again).

I've not tested this yet because I wanted to get a second set of eyes before I run it against production.

Part of #49 