### PR TITLE
Fix dependency on env.app

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -29,8 +29,8 @@ def setup_sudo():
     Ensure members of `fabric` group can execute deployment scripts as root
     without passwords.
     """
-    sudoer_file_test = "/tmp/opencodelists_fabric_{}".format(env.app)
-    sudoer_file_real = "/etc/sudoers.d/opencodelists_fabric_{}".format(env.app)
+    sudoer_file_test = "/tmp/opencodelists_fabric_opencodelists"
+    sudoer_file_real = "/etc/sudoers.d/opencodelists_fabric_opencodelists"
     # Raise an exception if not set up
     check_setup = run(
         "/usr/bin/sudo -n {}/deploy/fab_scripts/test.sh".format(env.path),


### PR DESCRIPTION
Openprescribing has multiple deployments (prod and staging).  The `setup_sudo()` function was copied from OP's fabfile.  OP's fabfile differentiates between the two environments using env.app, but we don't have that distinction in opencodelists.  This removes the use of env.app but keeps the same format as OP in case we switch to a two env deployment model.