### PR TITLE
Add string-foot-gun guard to Hierarchy.from_codes

### DIFF
--- a/codelists/hierarchy.py
+++ b/codelists/hierarchy.py
@@ -24,6 +24,10 @@ class Hierarchy:
         in the coding system.
         """
 
+        if isinstance(codes, str):
+            msg = "Hierarchy was expecting codes to be a non-string iterable, you passed a string."
+            raise TypeError(msg)
+
         ancestor_relationships = set(coding_system.ancestor_relationships(codes))
         descendant_relationships = set(coding_system.descendant_relationships(codes))
         edges = ancestor_relationships | descendant_relationships


### PR DESCRIPTION
Hierarchy.from_codes will accept any type of iterable for its `codes` argument.  However if that iterable is a string it will produce a Hierarchy instance with no nodes.  The string is passed to the given `coding_system`'s ancestor/descendant relationships functions which cast it to a list.  In the case of a string this breaks it down into its contained characters, which doesn't return any [correct] results from the database.

Fixes #193 