### PR TITLE
Download Codelist from Builder

### DIFF
--- a/builder/urls.py
+++ b/builder/urls.py
@@ -15,4 +15,5 @@ urlpatterns = [
     ),
     path("<username>/<codelist_slug>/update/", views.update, name="update"),
     path("<username>/<codelist_slug>/search/", views.new_search, name="new_search"),
+    path("<username>/<codelist_slug>/download.csv", views.download, name="download"),
 ]

--- a/builder/views.py
+++ b/builder/views.py
@@ -33,7 +33,7 @@ def download(request, username, codelist_slug):
         coding_system = CODING_SYSTEMS["snomedct"]
 
     # get terms for codes
-    code_to_term = coding_system.get_code_to_term(codes)
+    code_to_term = coding_system.lookup_names(codes)
 
     timestamp = timezone.now().strftime("%Y-%m-%dT%H-%M-%S")
     filename = f"{username}-{codelist_slug}-{timestamp}.csv"

--- a/builder/views.py
+++ b/builder/views.py
@@ -24,7 +24,9 @@ def download(request, username, codelist_slug):
     codelist = get_object_or_404(DraftCodelist, owner=username, slug=codelist_slug)
 
     # get codes
-    codes = list(codelist.codes.values_list("code", flat=True))
+    codes = list(
+        codelist.codes.filter(status__contains="+").values_list("code", flat=True)
+    )
 
     # get coding_system module (and prepare for CTV3 integration)
     if codelist.coding_system_id in ["ctv3", "ctv3tpp"]:

--- a/builder/views.py
+++ b/builder/views.py
@@ -1,12 +1,15 @@
+import csv
 import json
 import re
 
 from django.contrib.auth.decorators import login_required
-from django.http import JsonResponse
+from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
+from django.utils import timezone
 from django.views.decorators.http import require_http_methods
 
+from codelists.coding_systems import CODING_SYSTEMS
 from codelists.hierarchy import Hierarchy
 from codelists.presenters import tree_tables
 from codelists.search import do_search
@@ -15,6 +18,35 @@ from opencodelists.models import User
 from . import actions
 from .forms import DraftCodelistForm
 from .models import DraftCodelist
+
+
+def download(request, username, codelist_slug):
+    codelist = get_object_or_404(DraftCodelist, owner=username, slug=codelist_slug)
+
+    # get codes
+    codes = list(codelist.codes.values_list("code", flat=True))
+
+    # get coding_system module (and prepare for CTV3 integration)
+    if codelist.coding_system_id in ["ctv3", "ctv3tpp"]:
+        coding_system = CODING_SYSTEMS["ctv3"]
+    else:
+        coding_system = CODING_SYSTEMS["snomedct"]
+
+    # get terms for codes
+    code_to_term = coding_system.get_code_to_term(codes)
+
+    timestamp = timezone.now().strftime("%Y-%m-%dT%H-%M-%S")
+    filename = f"{username}-{codelist_slug}-{timestamp}.csv"
+
+    response = HttpResponse(content_type="text/csv")
+    response["Content-Disposition"] = f'attachment; filename="{filename}"'
+
+    # render to csv
+    writer = csv.writer(response)
+    writer.writerow(["id", "term"])
+    writer.writerows([(k, v) for k, v in code_to_term.items()])
+
+    return response
 
 
 @login_required
@@ -97,6 +129,9 @@ def codelist(request, username, codelist_slug, search_slug=None):
     search_url = reverse(
         "builder:new_search", args=[codelist.owner.username, codelist.slug]
     )
+    download_url = reverse(
+        "builder:download", args=[codelist.owner.username, codelist.slug]
+    )
 
     ctx = {
         "user": codelist.owner,
@@ -117,6 +152,7 @@ def codelist(request, username, codelist_slug, search_slug=None):
         "is_editable": request.user == codelist.owner,
         "update_url": update_url,
         "search_url": search_url,
+        "download_url": download_url,
         # }
     }
 

--- a/coding_systems/snomedct/coding_system.py
+++ b/coding_systems/snomedct/coding_system.py
@@ -85,11 +85,3 @@ def descendant_relationships(codes):
     """
 
     return query(sql, codes)
-
-
-def get_code_to_term(codes):
-    """Look up terms for the given codes."""
-
-    concepts = Concept.objects.filter(pk__in=codes).prefetch_related("descriptions")
-
-    return {concept.pk: concept.fully_specified_name for concept in concepts}

--- a/coding_systems/snomedct/coding_system.py
+++ b/coding_systems/snomedct/coding_system.py
@@ -85,3 +85,11 @@ def descendant_relationships(codes):
     """
 
     return query(sql, codes)
+
+
+def get_code_to_term(codes):
+    """Look up terms for the given codes."""
+
+    concepts = Concept.objects.filter(pk__in=codes).prefetch_related("descriptions")
+
+    return {concept.pk: concept.fully_specified_name for concept in concepts}

--- a/static/src/js/builder/codelistbuilder.jsx
+++ b/static/src/js/builder/codelistbuilder.jsx
@@ -175,6 +175,11 @@ class CodelistBuilder extends React.Component {
 
             <h3 className="mb-4">New term search</h3>
             <SearchForm searchURL={this.props.searchURL} />
+            <hr />
+
+            <a className="btn btn-primary" href={this.props.downloadURL}>
+              Download codelist
+            </a>
           </div>
 
           <div className="col-9 pl-5">

--- a/static/src/js/builder/codelistbuilder.jsx
+++ b/static/src/js/builder/codelistbuilder.jsx
@@ -177,9 +177,12 @@ class CodelistBuilder extends React.Component {
             <SearchForm searchURL={this.props.searchURL} />
             <hr />
 
-            <a className="btn btn-primary" href={this.props.downloadURL}>
+            <DownloadButton
+              enabled={this.counts()["!"] === 0 && this.counts()["?"] === 0}
+              url={this.props.downloadURL}
+            >
               Download codelist
-            </a>
+            </DownloadButton>
           </div>
 
           <div className="col-9 pl-5">
@@ -485,6 +488,27 @@ function Summary(props) {
         </li>
       )}
     </ul>
+  );
+}
+
+function DownloadButton(props) {
+  if (props.enabled) {
+    return (
+      <a className="btn btn-primary" href={props.url}>
+        {props.children}
+      </a>
+    );
+  }
+
+  // Button is disabled, tell the user why
+  return (
+    <>
+      <p>
+        Downloads are disabled until all conflicted or unresolved concepts are
+        resolved.
+      </p>
+      <a className="disabled btn btn-secondary text-white">{props.children}</a>
+    </>
   );
 }
 

--- a/static/src/js/builder/index.jsx
+++ b/static/src/js/builder/index.jsx
@@ -26,6 +26,7 @@ ReactDOM.render(
     updateURL={readValueFromPage("update-url")}
     searchURL={readValueFromPage("search-url")}
     hierarchy={hierarchy}
+    downloadURL={readValueFromPage("download-url")}
   />,
   document.querySelector("#codelist-builder-container")
 );

--- a/templates/builder/codelist.html
+++ b/templates/builder/codelist.html
@@ -25,6 +25,7 @@
 {{ is_editable|json_script:"isEditable" }}
 {{ update_url|json_script:"update-url" }}
 {{ search_url|json_script:"search-url" }}
+{{ download_url|json_script:"download-url" }}
 
 <script src="{% static 'js/builder.bundle.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
This adds a download button to the Codelist builder page which builds a CSV of the codelist (in code,term format).

The button is disabled on codelists with unresolved or conflicted concepts.

Fixes #200 