### PR TITLE
Define bnf.coding_systems.lookup_names

### DIFF
--- a/coding_systems/bnf/coding_system.py
+++ b/coding_systems/bnf/coding_system.py
@@ -72,6 +72,9 @@ def code_to_term(codes):
     return dict(Concept.objects.filter(code__in=codes).values_list("code", "name"))
 
 
+lookup_names = code_to_term
+
+
 def codes_by_type(codes, hierarchy):
     codes_by_chapter = defaultdict(list)
     for code in codes:


### PR DESCRIPTION
I'm in the middle of another piece of work that will make lookup_names
redundant.