### PR TITLE
Remove warning banner for SNOMED CT codes

### DIFF
--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -16,14 +16,6 @@
 </h3>
 <br />
 
-{% if codelist.coding_system_id == "snomedct" %}
-<div class="alert alert-primary mb-5" role="alert">
-  SNOMED CT codelists have been automatically generated and have not been
-  reviewed for accuracy. For more information click
-  <a href="https://github.com/opensafely/documentation/blob/master/snomed.md">here</a>.
-</div>
-{% endif %}
-
 <div class="row">
   <div class="col-md-3 col-lg-2">
     <div class="btn-group btn-block" role="group">


### PR DESCRIPTION
* Some SNOMED CT codelists have not been automatically generated
* We're now more confident in the mapping (since #117)
* The codelist description explains that the codelist has been
    automatically generated