### PR TITLE
Fix Reference Removal

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,6 +9,9 @@
         "prettier",
         "prettier/react"
     ],
+    "ignorePatterns": [
+        "static/src/js/codelist.js"
+    ],
     "parserOptions": {
         "ecmaFeatures": {
             "jsx": true

--- a/static/src/js/codelist.js
+++ b/static/src/js/codelist.js
@@ -42,8 +42,10 @@ $(document).ready(() => {
   $("#add-reference").click((event) => addForm("reference", event));
   $("#add-signoff").click((event) => addForm("signoff", event));
 
-  $(".remove-reference").bind("click", (event) =>
+  $(document).on("click", ".remove-reference", (event) =>
     removeRow("reference", event)
   );
-  $(".remove-signoff").bind("click", (event) => removeRow("signoff", event));
+  $(document).on("click", ".remove-signoff", (event) =>
+    removeRow("signoff", event)
+  );
 });


### PR DESCRIPTION
This fixes removing References from the new Codelist form by using the correct event handler for dynamic elements.

Fixes #244 