### PR TITLE
Fix Missing Variables on DM+D Codelists

### DIFF
--- a/codelists/views.py
+++ b/codelists/views.py
@@ -291,6 +291,8 @@ def version(request, project_slug, codelist_slug, qualified_version_str):
 
     definition_rows = {}
     child_map = None
+    code_to_status = None
+    code_to_term = None
     parent_map = None
     tree_tables = None
     if clv.coding_system_id in ["ctv3", "ctv3tpp", "snomedct"]:


### PR DESCRIPTION
[Sentry](https://sentry.io/organizations/ebm-datalab/issues/1957257441/?project=5248013&query=is%3Aunresolved)

We don't have the `code_to_term`or `code_to_status` lookups for the DM+D Coding System yet, and we're not building a Definition or Tree view for Codelists in that system yet, so don't need those variables yet.

Fixes #273 