### PR TITLE
Fix Edit Codelist Form

### DIFF
--- a/codelists/tests/test_views.py
+++ b/codelists/tests/test_views.py
@@ -226,7 +226,30 @@ def test_codelistupdate_invalid_post(rf):
     assert response.context_data["signoff_formset"].errors
 
 
-def test_codelistupdate_success(rf):
+def test_codelistupdate_success_get(rf):
+    codelist = CodelistFactory()
+    SignOffFactory(codelist=codelist)
+    SignOffFactory(codelist=codelist)
+    ReferenceFactory(codelist=codelist)
+    ReferenceFactory(codelist=codelist)
+
+    request = rf.get("/")
+    request.user = UserFactory()
+    response = CodelistUpdate.as_view()(
+        request, project_slug=codelist.project.slug, codelist_slug=codelist.slug
+    )
+
+    assert response.status_code == 200
+
+    form = response.context_data["codelist_form"]
+    assert form.data["name"] == codelist.name
+    assert form.data["project"] == codelist.project
+    assert form.data["coding_system_id"] == codelist.coding_system_id
+    assert form.data["description"] == codelist.description
+    assert form.data["methodology"] == codelist.methodology
+
+
+def test_codelistupdate_success_post(rf):
     codelist = CodelistFactory()
     signoff_1 = SignOffFactory(codelist=codelist)
     signoff_2 = SignOffFactory(codelist=codelist)

--- a/codelists/views.py
+++ b/codelists/views.py
@@ -143,8 +143,29 @@ class CodelistUpdate(TemplateView):
 
         return super().dispatch(request, *args, **kwargs)
 
+    def get(self, request, *args, **kwargs):
+        codelist_form = CodelistUpdateForm(
+            {
+                "name": self.codelist.name,
+                "project": self.codelist.project,
+                "coding_system_id": self.codelist.coding_system_id,
+                "description": self.codelist.description,
+                "methodology": self.codelist.methodology,
+            }
+        )
+
+        reference_formset = self.get_reference_formset()
+        signoff_formset = self.get_signoff_formset()
+
+        context = self.get_context_data(
+            codelist_form=codelist_form,
+            reference_formset=reference_formset,
+            signoff_formset=signoff_formset,
+        )
+        return self.render_to_response(context)
+
     def post(self, request, *args, **kwargs):
-        codelist_form = self.get_form(request.POST, request.FILES)
+        codelist_form = CodelistUpdateForm(request.POST, request.FILES)
         reference_formset = self.get_reference_formset(request.POST, request.FILES)
         signoff_formset = self.get_signoff_formset(request.POST, request.FILES)
 
@@ -193,20 +214,6 @@ class CodelistUpdate(TemplateView):
         )
         return self.render_to_response(context)
 
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-
-        if "codelist_form" not in kwargs:
-            context["codelist_form"] = self.get_form()
-
-        if "reference_formset" not in kwargs:
-            context["reference_formset"] = self.get_reference_formset()
-
-        if "signoff_formset" not in kwargs:
-            context["signoff_formset"] = self.get_signoff_formset()
-
-        return context
-
     def save_formset(self, formset, codelist):
         """
         Save the the given FormSet
@@ -224,9 +231,6 @@ class CodelistUpdate(TemplateView):
         # https://docs.djangoproject.com/en/3.0/topics/forms/formsets/#can-delete
         for obj in formset.deleted_objects:
             obj.delete()
-
-    def get_form(self, data=None, files=None):
-        return CodelistUpdateForm(data, files)
 
     def get_reference_formset(self, data=None, files=None):
         return ReferenceFormSet(


### PR DESCRIPTION
This fixes the Edit Codelist Form being blank when you edit a Codelist.  It instantiates the CodelistUpdateForm with the necessary values from the existing `Codelist`.

I've removed the `get_form` method now that get/post have diverged enough to remove the abstractions usefulness.