### PR TITLE
Fix Deleting Related Forms

### DIFF
--- a/codelists/forms.py
+++ b/codelists/forms.py
@@ -9,6 +9,20 @@ from django.forms.models import fields_for_model
 from .models import Codelist, CodelistVersion, Reference, SignOff
 
 
+def data_without_delete(cleaned_data):
+    """
+    Return data from this form without the DELETE key.
+
+    When used with a formset_factory()'s can_delete kwarg a Form will gain
+    a DELETE checkbox in the rendered <form>.  A FormSet uses this to know
+    which submitted Forms have been deleted in the UI.
+
+    However, we don't want that key when passing it to an action/the ORM.
+    This function strips that key for us.
+    """
+    return {k: v for k, v in cleaned_data.items() if k != "DELETE"}
+
+
 def model_field(model, fieldname):
     """Return a Field instance with arguments from the model definition."""
 

--- a/codelists/views.py
+++ b/codelists/views.py
@@ -24,6 +24,7 @@ from .forms import (
     ReferenceFormSet,
     SignOffForm,
     SignOffFormSet,
+    data_without_delete,
 )
 from .hierarchy import Hierarchy
 from .models import Codelist, CodelistVersion
@@ -50,8 +51,8 @@ def index(request):
 
 @method_decorator(login_required, name="dispatch")
 class CodelistCreate(TemplateView):
-    ReferenceFormSet = formset_factory(ReferenceForm)
-    SignOffFormSet = formset_factory(SignOffForm)
+    ReferenceFormSet = formset_factory(ReferenceForm, can_delete=True)
+    SignOffFormSet = formset_factory(SignOffForm, can_delete=True)
     template_name = "codelists/codelist.html"
 
     def dispatch(self, request, *args, **kwargs):
@@ -77,8 +78,16 @@ class CodelistCreate(TemplateView):
 
     def all_valid(self, codelist_form, reference_formset, signoff_formset):
         # get changed forms so we ignore empty form instances
-        references = (f.cleaned_data for f in reference_formset if f.has_changed())
-        signoffs = (f.cleaned_data for f in signoff_formset if f.has_changed())
+        references = (
+            data_without_delete(f.cleaned_data)
+            for f in reference_formset
+            if f.has_changed()
+        )
+        signoffs = (
+            data_without_delete(f.cleaned_data)
+            for f in signoff_formset
+            if f.has_changed()
+        )
 
         name = codelist_form.cleaned_data["name"]
 

--- a/static/src/js/codelist.js
+++ b/static/src/js/codelist.js
@@ -24,13 +24,10 @@ const removeRow = (name, event) => {
   const formId = classes[0];
   const form = document.getElementById(formId);
 
-  // add an <name>-DELETE element to tell the formset we're deleting this
+  // flip the <name>-DELETE checkbox to tell the formset we're deleting this
   // form from the formset
-  const deleted = document.createElement("input");
-  deleted.setAttribute("type", "hidden");
-  deleted.setAttribute("name", `${formId}-DELETE`);
+  const deleted = document.getElementById(`${formId}-DELETE`);
   deleted.setAttribute("value", "on");
-  form.appendChild(deleted);
 
   // hide the deleted form
   form.classList.add("d-none");

--- a/templates/codelists/_reference_form.html
+++ b/templates/codelists/_reference_form.html
@@ -1,4 +1,4 @@
-<div id="reference-{{ id }}" class="row mb-4">
+<div id="reference-{{ id }}" class="row mb-4{% if form.DELETE.value %} d-none{% endif %}">
 
   <input
     type="hidden"
@@ -83,5 +83,14 @@
       &times;
     </button>
   </div>
+
+  <input
+    type="hidden"
+    id="reference-{{ id }}-DELETE"
+    name="reference-{{ id }}-DELETE"
+    {% if form.DELETE.value %}
+    value="on"
+    {% endif %}
+    />
 
 </div>


### PR DESCRIPTION
This turns on deleting related existing forms in the Reference and SignOff FormSets and modifies the template to retain the choices made by a User.

Fixes #244 