### PR TITLE
Fix crontab syntax

### DIFF
--- a/deploy/cron/opencodelists
+++ b/deploy/cron/opencodelists
@@ -1,1 +1,1 @@
-00 01 * * * ebmbot /var/www/opencodelists/deploy/bin/backup.sh
+00 01 * * * /var/www/opencodelists/deploy/bin/backup.sh


### PR DESCRIPTION
Because we're loading the crontab with `crontab -l`, we don't need the
user.  As it was, the user is being interpreted as the command to run.