### PR TITLE
Fix 500 errors

### DIFF
--- a/codelists/models.py
+++ b/codelists/models.py
@@ -212,6 +212,13 @@ class CodelistVersion(models.Model):
         return rows
 
     @cached_property
+    def all_related_codes(self):
+        if self.csv_data:
+            return self._old_style_codes()
+        else:
+            return self.code_objs.values_list("code", flat=True)
+
+    @cached_property
     def codes(self):
         if self.csv_data:
             return self._old_style_codes()

--- a/codelists/views/version.py
+++ b/codelists/views/version.py
@@ -23,7 +23,7 @@ def version(request, clv):
         else:
             coding_system = CODING_SYSTEMS["snomedct"]
 
-        hierarchy = Hierarchy.from_codes(coding_system, clv.codes)
+        hierarchy = Hierarchy.from_codes(coding_system, clv.all_related_codes)
         parent_map = {p: list(cc) for p, cc in hierarchy.parent_map.items()}
         child_map = {c: list(pp) for c, pp in hierarchy.child_map.items()}
         code_to_term = coding_system.code_to_term(hierarchy.nodes)


### PR DESCRIPTION
These are caused by code_to_term not containing ancestors codes that
match a search term and have been excluded with all their descendants.
This is a problem, because we now show search terms on the main version
page.

Tests to follow, but fix is urgent.