### PR TITLE
Ensure that the downloaded CSVs for old-style codelists is unchanged

### DIFF
--- a/codelists/models.py
+++ b/codelists/models.py
@@ -251,6 +251,8 @@ class CodelistVersion(models.Model):
         )
 
     def csv_data_for_download(self):
+        if self.csv_data:
+            return self.csv_data
         buf = StringIO()
         writer = csv.writer(buf)
         writer.writerows(self.table)


### PR DESCRIPTION
A change was introduced in #390 that changed the line endings of
downloaded CSVs.  This broke all the tests in study repos.