### PR TITLE
Don't crash if publishing a published version

### DIFF
--- a/codelists/actions.py
+++ b/codelists/actions.py
@@ -142,8 +142,6 @@ def publish_version(*, version):
 
     logger.info("Published Version", version_pk=version.pk)
 
-    return version
-
 
 @transaction.atomic
 def convert_codelist_to_new_style(*, codelist):

--- a/codelists/views/version_publish.py
+++ b/codelists/views/version_publish.py
@@ -11,10 +11,6 @@ from .decorators import load_version, require_permission
 @load_version
 @require_permission
 def version_publish(request, version):
-    # We want to redirect to the now-published Version after publishing it, but
-    # the in-memory instance in this view won't be updated by the .save() call
-    # inside the action.  So instead we return the new instance from the action
-    # and use that.
-    version = actions.publish_version(version=version)
-
+    if version.is_draft:
+        actions.publish_version(version=version)
     return redirect(version)


### PR DESCRIPTION
Publishing an already-published version doesn't matter.

This also removes comment added in 94bffe71 about behaviour introduced
in d26f4d68.  As far as I can tell, the comment is incorrect.

Fixes #396.