### PR TITLE
Reinstate dm+d download button for BNF codelists

### DIFF
--- a/codelists/models.py
+++ b/codelists/models.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.text import slugify
 
+from mappings.bnfdmd.mappers import bnf_to_dmd
 from opencodelists.hash_utils import hash
 
 from .coding_systems import CODING_SYSTEMS
@@ -161,6 +162,12 @@ class CodelistVersion(models.Model):
             f"codelists:{self.codelist_type}_version_download", kwargs=self.url_kwargs
         )
 
+    def get_dmd_download_url(self):
+        return reverse(
+            f"codelists:{self.codelist_type}_version_dmd_download",
+            kwargs=self.url_kwargs,
+        )
+
     def get_create_url(self):
         return reverse(
             f"codelists:{self.codelist_type}_version_create", kwargs=self.url_kwargs
@@ -260,6 +267,15 @@ class CodelistVersion(models.Model):
         buf = StringIO()
         writer = csv.writer(buf)
         writer.writerows(self.table)
+        return buf.getvalue()
+
+    def dmd_csv_data_for_download(self):
+        assert self.coding_system_id == "bnf"
+        buf = StringIO()
+        writer = csv.writer(buf)
+        writer = csv.DictWriter(buf, ["dmd_type", "dmd_id", "dmd_name", "bnf_code"])
+        writer.writeheader()
+        writer.writerows(bnf_to_dmd(self.codes))
         return buf.getvalue()
 
     def download_filename(self):

--- a/codelists/urls.py
+++ b/codelists/urls.py
@@ -48,6 +48,7 @@ for subpath, view in [
     ("<codelist_slug>/<tag_or_hash>/create-new-version/", views.version_create),
     ("<codelist_slug>/<tag_or_hash>/publish/", views.version_publish),
     ("<codelist_slug>/<tag_or_hash>/download.csv", views.version_download),
+    ("<codelist_slug>/<tag_or_hash>/dmd-download.csv", views.version_dmd_download),
 ]:
     urlpatterns.append(
         path(

--- a/codelists/views/__init__.py
+++ b/codelists/views/__init__.py
@@ -4,6 +4,7 @@ from .codelist_update import codelist_update
 from .index import index
 from .version import version
 from .version_create import version_create
+from .version_dmd_download import version_dmd_download
 from .version_download import version_download
 from .version_publish import version_publish
 from .version_upload import version_upload

--- a/codelists/views/version_dmd_download.py
+++ b/codelists/views/version_dmd_download.py
@@ -1,0 +1,14 @@
+from django.http import HttpResponse
+
+from .decorators import load_version
+
+
+@load_version
+def version_dmd_download(request, clv):
+    response = HttpResponse(content_type="text/csv")
+    content_disposition = 'attachment; filename="{}-dmd.csv"'.format(
+        clv.download_filename()
+    )
+    response["Content-Disposition"] = content_disposition
+    response.write(clv.dmd_csv_data_for_download())
+    return response

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -18,7 +18,7 @@
 
 <div class="row">
   <div class="col-md-3 col-lg-2">
-    <div class="btn-group btn-block" role="group">
+    <div class="btn-group-vertical btn-block" role="group">
       <a
         href="{{ clv.get_download_url }}"
         role="button"
@@ -26,6 +26,15 @@
       >
         Download CSV
       </a>
+      {% if clv.coding_system_id == "bnf" %}
+      <a
+        href="{{ clv.get_dmd_download_url }}"
+        role="button"
+        class="btn btn-outline-info btn-block"
+      >
+        Download dm+d
+      </a>
+      {% endif %}
     </div>
     <hr />
 


### PR DESCRIPTION
It got lost when we moved CSV downloadings out of the builder