### PR TITLE
Add <strong> and <em> to allowed markdown tags

### DIFF
--- a/opencodelists/settings.py
+++ b/opencodelists/settings.py
@@ -208,6 +208,8 @@ MARKDOWN_FILTER_WHITELIST_TAGS = [
     "ul",
     "li",
     "code",
+    "em",
+    "strong",
 ]
 
 


### PR DESCRIPTION
Fixes #441.

@ghickman can you think of any other tags that should be allowed?