### PR TITLE
Bump gunicorn timeout

### DIFF
--- a/deploy/gunicorn/conf.py
+++ b/deploy/gunicorn/conf.py
@@ -2,7 +2,7 @@ from services.logging import logging_config_dict
 
 bind = "unix:/tmp/gunicorn-opencodelists.sock"
 workers = 2
-timeout = 30
+timeout = 60
 
 # Where to log to (stdout and stderr)
 accesslog = "-"


### PR DESCRIPTION
For codelists with a lot of searches, exporting the codelist to the
buidler to be edited takes longer than 30s.  This is because we repeat
each search and this can be slow.

A better fix would be add FTS indexes to speed up searching, but for now
bumping the gunicorn timeout will have to do.