### PR TITLE
Show tree and definition tabs for ICD-10 codelists

### DIFF
--- a/codelists/views/version.py
+++ b/codelists/views/version.py
@@ -17,7 +17,7 @@ def version(request, clv):
     code_to_term = None
     parent_map = None
     tree_tables = None
-    if clv.coding_system_id in ["bnf", "ctv3", "ctv3tpp", "snomedct"]:
+    if clv.coding_system_id in ["bnf", "ctv3", "ctv3tpp", "icd10", "snomedct"]:
         if clv.coding_system_id in ["ctv3", "ctv3tpp"]:
             coding_system = CODING_SYSTEMS["ctv3"]
         else:

--- a/templates/codelists/_definition_rows.html
+++ b/templates/codelists/_definition_rows.html
@@ -3,9 +3,9 @@
 <ul>
   {% for row in rows %}
   <li>
-    <a href="{% concept_url codelist.coding_system_id row.code %}" style="color: blue">
+    <span style="color: blue">
       {{ row.name }}
-    </a>
+    </span>
     (<code>{{ row.code }}</code>)
 
     {% if row.all_descendants %}
@@ -17,9 +17,9 @@
 
       {% for child in row.excluded_descendants %}
       <li>
-        <a href="{% concept_url codelist.coding_system_id child.code %}" style="color: black">
+        <span style="color: black">
           {{ child.name }}
-        </a>
+        </span>
         (<code>{{ child.code }}</code>)
       </li>
       {% endfor %}


### PR DESCRIPTION
This also removes links to the browser from the definition tab, since we
have not created a browser for ICD-10 (and the existing browsers aren't
very good)