### PR TITLE
Fix tree view

### DIFF
--- a/static/src/js/common/tree-tables.jsx
+++ b/static/src/js/common/tree-tables.jsx
@@ -137,22 +137,20 @@ function TreeRow(props) {
 
   return (
     <div className={className} data-code={code} data-path={path}>
-      {updateStatus && (
-        <div className="btn-group btn-group-sm" role="group">
-          <StatusToggle
-            code={code}
-            symbol="+"
-            status={status}
-            updateStatus={updateStatus}
-          />
-          <StatusToggle
-            code={code}
-            symbol="-"
-            status={status}
-            updateStatus={updateStatus}
-          />
-        </div>
-      )}
+      <div className="btn-group btn-group-sm" role="group">
+        <StatusToggle
+          code={code}
+          symbol="+"
+          status={status}
+          updateStatus={updateStatus}
+        />
+        <StatusToggle
+          code={code}
+          symbol="-"
+          status={status}
+          updateStatus={updateStatus}
+        />
+      </div>
 
       {showMoreInfoModal && (
         <MoreInfoButton code={code} showMoreInfoModal={showMoreInfoModal} />
@@ -191,7 +189,7 @@ function StatusToggle(props) {
   return (
     <button
       type="button"
-      onClick={updateStatus.bind(null, code, symbol)}
+      onClick={updateStatus && updateStatus.bind(null, code, symbol)}
       className={buttonClasses.join(" ")}
       data-symbol={symbol}
     >


### PR DESCRIPTION
This was broken by fa47d6ca.

Users who didn't own the codelist saw:

![image](https://user-images.githubusercontent.com/28734/104757829-70b9e600-5755-11eb-9fb9-2e14a097fa27.png)

They now see:

![image](https://user-images.githubusercontent.com/28734/104757870-7fa09880-5755-11eb-9b82-0295ab2a9385.png)

and nothing happens if you click the buttons.